### PR TITLE
fix: add nullable constraint for FK repos -> organization

### DIFF
--- a/src/database/migrations/1733435340266_add_github_repos.js
+++ b/src/database/migrations/1733435340266_add_github_repos.js
@@ -64,8 +64,8 @@ exports.up = async (knex) => {
     table.enu('secret_scanning_validity_checks_status', ['enabled', 'disabled']).defaultTo('disabled')
 
     // Foreign key to 'github_organizations' table
-    table
-      .integer('github_organization_id')
+    table.integer('github_organization_id')
+      .notNullable()
       .unsigned()
       .references('id')
       .inTable('github_organizations')

--- a/src/database/schema/schema.sql
+++ b/src/database/schema/schema.sql
@@ -349,7 +349,7 @@ CREATE TABLE public.github_repositories (
     dependabot_security_updates_status text DEFAULT 'disabled'::text,
     secret_scanning_non_provider_patterns_status text DEFAULT 'disabled'::text,
     secret_scanning_validity_checks_status text DEFAULT 'disabled'::text,
-    github_organization_id integer,
+    github_organization_id integer NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     CONSTRAINT github_repositories_dependabot_security_updates_status_check CHECK ((dependabot_security_updates_status = ANY (ARRAY['enabled'::text, 'disabled'::text]))),


### PR DESCRIPTION
Work on #139. It seemed there could be more room for improvement but, semantic issues with fields aside, integrity constraints were well placed but a nullable constraint for FK in the relationship _repos -> organization_, which is fixed here. cc/ @bjohansebas @UlisesGascon 