### PR TITLE
Add CLI support for checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,27 @@ There is an specific workflow that runs all the checks sequentially:
 node index.js workflow run run-all-checks
 ```
 
+### Checklist
+
+The checklist are collections of checks. You can list the available list by running:
+
+```bash
+node index.js checklist list
+```
+
+Run a specific checklist:
+
+```bash
+node index.js checklist run [--name <name>]
+```
+
+
+It is possible also to define a project scope:
+
+```bash
+node index.js checklist run [--name <name>] [--project-scope <name1,name2,...>]
+```
+
 ## Database Management
 
 ### Migrations

--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@ const { Command } = require('commander')
 const { getConfig } = require('./src/config')
 const { projectCategories, dbSettings } = getConfig()
 const { logger } = require('./src/utils')
-const { runAddProjectCommand, runWorkflowCommand, listWorkflowCommand, listCheckCommand, runCheckCommand } = require('./src/cli')
+const { runAddProjectCommand, runWorkflowCommand, listWorkflowCommand, listCheckCommand, runCheckCommand, runChecklist, listChecklist } = require('./src/cli')
 const knex = require('knex')(dbSettings)
 
 const program = new Command()
 
-const project = program.command('project').description('Manage projects')
+const project = program
+  .command('project')
+  .description('Manage projects')
 
 // Project related commands
 project
@@ -28,7 +30,9 @@ project
   })
 
 // Workflows related commands
-const workflow = program.command('workflow').description('Manage workflows')
+const workflow = program
+  .command('workflow')
+  .description('Manage workflows')
 
 workflow
   .command('run')
@@ -53,7 +57,9 @@ workflow
   })
 
 // Checks related commands
-const check = program.command('check').description('Manage checks')
+const check = program
+  .command('check')
+  .description('Manage checks')
 
 check
   .command('list')
@@ -76,6 +82,41 @@ check
   .action(async (options) => {
     try {
       await runCheckCommand(knex, options)
+    } catch (error) {
+      logger.error(error)
+      process.exit(1)
+    } finally {
+      await knex.destroy()
+    }
+  })
+
+// Checklists related commands
+const checklist = program
+  .command('checklist')
+  .description('Manage checklists')
+
+checklist
+  .command('list')
+  .description('List all available checklists')
+  .action(async (options) => {
+    try {
+      await listChecklist(knex, options)
+    } catch (error) {
+      logger.error(error)
+      process.exit(1)
+    } finally {
+      await knex.destroy()
+    }
+  })
+
+checklist
+  .command('run')
+  .description('Run a checklist')
+  .option('--name <name>', 'Name of the checklist')
+  .option('--project-scope <projects...>', 'Scope of the checklist')
+  .action(async (options) => {
+    try {
+      await runChecklist(knex, options)
     } catch (error) {
       logger.error(error)
       process.exit(1)

--- a/src/checks/complianceChecks/softwareDesignTraining.js
+++ b/src/checks/complianceChecks/softwareDesignTraining.js
@@ -2,16 +2,19 @@ const validators = require('../validators')
 const { initializeStore } = require('../../store')
 const debug = require('debug')('checks:softwareDesignTraining')
 
-module.exports = async (knex) => {
+module.exports = async (knex, { projects } = {}) => {
   const {
-    getAllSSoftwareDesignTrainings, getCheckByCodeName,
+    getAllSSoftwareDesignTrainingsByProjectIds, getCheckByCodeName,
     getAllProjects, addAlert, addTask, upsertComplianceCheckResult,
     deleteAlertsByComplianceCheckId, deleteTasksByComplianceCheckId
   } = initializeStore(knex)
   debug('Collecting relevant data...')
   const check = await getCheckByCodeName('softwareDesignTraining')
-  const trainings = await getAllSSoftwareDesignTrainings()
-  const projects = await getAllProjects()
+  if (!projects || (Array.isArray(projects) && projects.length === 0)) {
+    projects = await getAllProjects()
+  }
+
+  const trainings = await getAllSSoftwareDesignTrainingsByProjectIds(projects.map(project => project.id))
 
   debug('Extracting the validation results...')
   const analysis = validators.softwareDesignTraining({ trainings, check, projects })

--- a/src/cli/checklists.js
+++ b/src/cli/checklists.js
@@ -1,0 +1,89 @@
+const inquirer = require('inquirer').default
+const { initializeStore } = require('../store')
+const { logger } = require('../utils')
+const debug = require('debug')('cli:checklists')
+const { stringToArray } = require('@ulisesgascon/string-to-array')
+const checks = require('../checks')
+
+async function listChecklist (knex, options = {}) {
+  const { getAllChecklists } = initializeStore(knex)
+  const checklists = await getAllChecklists(knex)
+  checklists.forEach(checklist => {
+    logger.info(`- [${checklist.author}][${checklist.code_name}] ${checklist.title}`)
+  })
+  logger.info('------------------------------------')
+  logger.info(`Available checklists: ${checklists.length}.`)
+  return checklists
+}
+
+async function runChecklist (knex, options = {}) {
+  const { getAllChecklists, getAllProjects, getAllChecksInChecklistById } = initializeStore(knex)
+  const checklists = await getAllChecklists(knex)
+  const projects = await getAllProjects(knex)
+  const validCommandNames = checklists.map((item) => item.code_name)
+  const validProjectNames = ['ALL'].concat(projects.map((item) => item.name))
+
+  if (Object.keys(options).length && !validCommandNames.includes(options.name)) {
+    throw new Error('Invalid checklist name. Please enter a valid checklist name.')
+  }
+
+  if (options.projectScope && options.projectScope.length > 0) {
+    const invalidProjects = stringToArray(options.projectScope[0]).filter((project) => !validProjectNames.includes(project))
+    if (invalidProjects.length > 0) {
+      throw new Error(`Invalid project names: ${invalidProjects.join(', ')}`)
+    }
+  }
+
+  if (validProjectNames.length === 1) {
+    throw new Error('No projects in database. Please add projects to run checklists')
+  }
+
+  const answers = options.name
+    ? options
+    : await inquirer.prompt([
+      {
+        type: 'list',
+        name: 'name',
+        message: 'What is the name (code_name) of the checklist?',
+        choices: validCommandNames,
+        when: () => !options.name
+      },
+      {
+        type: 'checkbox',
+        name: 'projectScope',
+        choices: validProjectNames,
+        message: 'Choose the projects to run the checklist against',
+        when: () => !options.name
+      }
+    ])
+
+  if (!answers.projectScope || answers.projectScope?.length === 0 || stringToArray(answers.projectScope[0]).includes('ALL')) {
+    answers.projectScope = undefined
+    logger.info('Running checklist against all projects')
+  } else {
+    const projectsSelected = stringToArray(answers.projectScope[0])
+    answers.projectScope = projectsSelected.map(p => projects.find(project => project.name === p))
+    logger.info('Running checklist against specific projects')
+  }
+
+  debug('Running checklist with code_name:', answers.name)
+
+  const checklist = checklists.find(checklist => checklist.code_name === answers.name)
+  const checksToRun = await getAllChecksInChecklistById(knex, checklist.id)
+
+  for (const check of checksToRun) {
+    if (check.implementation_status !== 'completed') {
+      logger.info(`Check (${check.code_name}) is not implemented yet. skipping...`)
+      continue
+    }
+    logger.info(`Running check (${check.code_name})`)
+    await checks[check.code_name](knex, { projects: answers.projectScope })
+  }
+
+  logger.info(`Checklist (${answers.name}) ran successfully`)
+}
+
+module.exports = {
+  listChecklist,
+  runChecklist
+}

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,9 +1,11 @@
 const project = require('./project')
 const workflows = require('./workflows')
 const checks = require('./checks')
+const checklists = require('./checklists')
 
 module.exports = {
   ...project,
   ...workflows,
-  ...checks
+  ...checks,
+  ...checklists
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -93,6 +93,20 @@ const upsertGithubRepository = (knex) => (repository, orgId) => upsertRecord({
   data: { ...repository, github_organization_id: orgId }
 })
 
+const getAllChecksInChecklistById = (knex, checklistId) =>
+  debug(`Fetching all checks in checklist by id (${checklistId})...`) ||
+  knex('checklist_items')
+    .join('compliance_checks', 'compliance_checks.id', 'checklist_items.compliance_check_id')
+    .where('checklist_items.checklist_id', checklistId)
+    .select('compliance_checks.*')
+
+const getAllGithubOrganizationsByProjectsId = (knex, projectIds) => {
+  debug(`Fetching all github organizations by projects id (${projectIds})...`)
+  return knex('github_organizations')
+    .whereIn('github_organizations.project_id', projectIds)
+    .select('*')
+}
+
 const initializeStore = (knex) => {
   debug('Initializing store...')
   const getAll = getAllFn(knex)
@@ -113,6 +127,9 @@ const initializeStore = (knex) => {
     upsertComplianceCheckResult: upsertComplianceCheckResult(knex),
     getAllSSoftwareDesignTrainings: () => getAll('software_design_training'),
     getAllGithubRepositories: () => getAll('github_repositories'),
+    getAllChecklists: () => getAll('compliance_checklists'),
+    getAllChecksInChecklistById,
+    getAllGithubOrganizationsByProjectsId: (projectIds) => getAllGithubOrganizationsByProjectsId(knex, projectIds),
     upsertOSSFScorecard: upsertOSSFScorecard(knex)
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -107,6 +107,13 @@ const getAllGithubOrganizationsByProjectsId = (knex, projectIds) => {
     .select('*')
 }
 
+const getAllSSoftwareDesignTrainingsByProjectIds = (knex, projectIds) => {
+  debug(`Fetching all software design trainings by project ids (${projectIds})...`)
+  return knex('software_design_training')
+    .whereIn('software_design_training.project_id', projectIds)
+    .select('*')
+}
+
 const initializeStore = (knex) => {
   debug('Initializing store...')
   const getAll = getAllFn(knex)
@@ -130,6 +137,7 @@ const initializeStore = (knex) => {
     getAllChecklists: () => getAll('compliance_checklists'),
     getAllChecksInChecklistById,
     getAllGithubOrganizationsByProjectsId: (projectIds) => getAllGithubOrganizationsByProjectsId(knex, projectIds),
+    getAllSSoftwareDesignTrainingsByProjectIds: (projectIds) => getAllSSoftwareDesignTrainingsByProjectIds(knex, projectIds),
     upsertOSSFScorecard: upsertOSSFScorecard(knex)
   }
 }


### PR DESCRIPTION
### Main Changes
- Add CLI command `checklist` (9dd0767)
- Allow the checks `softwareDesignTraining` (db96f64) and `githubOrgMFA` (758de3b) to support scoped projects.

### Other Changes
- Extend store to support checklist operations (a873707)

### Context
- closes #163

### Screenshots


#### List available checklists using CLI

![Screenshot from 2024-12-24 22-21-37](https://github.com/user-attachments/assets/d8f1cf61-a657-4fa0-bf00-198192551b81)

#### Run a checklist using CLI with support

![Screenshot from 2024-12-24 22-20-55](https://github.com/user-attachments/assets/64625523-3918-407c-87d2-371838f1bb6c)
![Screenshot from 2024-12-24 22-21-17](https://github.com/user-attachments/assets/f83ad5b0-859a-4c54-aa9b-e394df159521)

#### Run a direct command to execute a checklist with a scoped organziation

![Screenshot from 2024-12-24 22-20-01](https://github.com/user-attachments/assets/f6a82840-17a8-4456-9f90-7c6416a06174)
![Screenshot from 2024-12-24 22-20-12](https://github.com/user-attachments/assets/73c4c62f-4a11-41fc-8ce0-a733d8f0b0f5)

#### Run a direct command to execute a checklist against all the organizations

![Screenshot from 2024-12-24 22-20-37](https://github.com/user-attachments/assets/b2224eb6-fbc4-4b40-b7b2-e7a17cfd685c)

### Changelog

- a873707 feat: extend store to support checklist operations by @UlisesGascon
- db96f64 feat: allow to run check `softwareDesignTraining` with scoped projects by @UlisesGascon
- 758de3b feat: allow to run check `githubOrgMFA` with scoped projects by @UlisesGascon
- 9dd0767 feat: add CLI command `checklist` by @UlisesGascon
