### PR TITLE
chore: refactor remaining database functions in testing env

### DIFF
--- a/__tests__/checks/githubOrgMFA.test.js
+++ b/__tests__/checks/githubOrgMFA.test.js
@@ -2,8 +2,7 @@ const knexInit = require('knex')
 const { getConfig } = require('../../src/config')
 const githubOrgMFA = require('../../src/checks/complianceChecks/githubOrgMFA')
 const {
-  resetDatabase, addProject, addGithubOrg, getAllResults, getAllTasks, getAllAlerts,
-  addAlert, addTask, addResult, getCheckByCodeName
+  resetDatabase, initializeStore
 } = require('../../__utils__')
 const { sampleGithubOrg } = require('../../__fixtures__')
 
@@ -13,14 +12,36 @@ let knex
 let project
 let check
 
+let addProject,
+  addGithubOrg,
+  getAllResults,
+  getAllTasks,
+  getAllAlerts,
+  addAlert,
+  addTask,
+  addResult,
+  getCheckByCodeName;
+
 beforeAll(async () => {
-  knex = knexInit(dbSettings)
-  check = await getCheckByCodeName(knex, 'githubOrgMFA')
+  knex = knexInit(dbSettings);
+  ({
+    addProject,
+    addGithubOrganization: addGithubOrg,
+    getAllResults,
+    getAllTasks,
+    getAllAlerts,
+    addAlert,
+    addTask,
+    addResult,
+    getAllGithubOrganizations,
+    getCheckByCodeName,
+  } = initializeStore(knex));
+  check = await getCheckByCodeName('githubOrgMFA')
 })
 
 beforeEach(async () => {
-  await resetDatabase(knex)
-  project = await addProject(knex, { name: sampleGithubOrg.login, category: 'impact' })
+  await resetDatabase(knex);
+  [project] = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
 })
 
 afterAll(async () => {
@@ -30,75 +51,85 @@ afterAll(async () => {
 describe('Integration: githubOrgMFA', () => {
   test('Should add results without alerts or tasks', async () => {
     // Add a passed check scenario
-    await addGithubOrg(knex, { login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id, two_factor_requirement_enabled: true })
+    await addGithubOrg({
+      login: sampleGithubOrg.login,
+      html_url: sampleGithubOrg.html_url,
+      project_id: project.id,
+      two_factor_requirement_enabled: true
+    })
     // Check that the database is empty
-    let results = await getAllResults(knex)
+    let results = await getAllResults()
     expect(results.length).toBe(0)
-    let alerts = await getAllAlerts(knex)
+    let alerts = await getAllAlerts()
     expect(alerts.length).toBe(0)
-    let tasks = await getAllTasks(knex)
+    let tasks = await getAllTasks()
     expect(tasks.length).toBe(0)
     // Run the check
     await expect(githubOrgMFA(knex)).resolves.toBeUndefined()
     // Check that the database has the expected results
-    results = await getAllResults(knex)
+    results = await getAllResults()
     expect(results.length).toBe(1)
     expect(results[0].status).toBe('passed')
     expect(results[0].compliance_check_id).toBe(check.id)
-    alerts = await getAllAlerts(knex)
+    alerts = await getAllAlerts()
     expect(alerts.length).toBe(0)
-    tasks = await getAllTasks(knex)
+    tasks = await getAllTasks()
     expect(tasks.length).toBe(0)
   })
 
   test('Should delete (previous alerts and tasks) and add results', async () => {
     // Prepare the Scenario
-    await addGithubOrg(knex, { login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id, two_factor_requirement_enabled: true })
-    await addAlert(knex, { compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
-    await addTask(knex, { compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    await addGithubOrg({
+      login: sampleGithubOrg.login,
+      html_url: sampleGithubOrg.html_url,
+      project_id: project.id,
+      two_factor_requirement_enabled: true
+    })
+    await addAlert({ compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    await addTask({ compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
     // Check that the database has the expected results
-    let results = await getAllResults(knex)
+    let results = await getAllResults()
     expect(results.length).toBe(0)
-    let alerts = await getAllAlerts(knex)
+    let alerts = await getAllAlerts()
     expect(alerts.length).toBe(1)
     expect(alerts[0].compliance_check_id).toBe(check.id)
-    let tasks = await getAllTasks(knex)
+    let tasks = await getAllTasks()
     expect(tasks.length).toBe(1)
     expect(tasks[0].compliance_check_id).toBe(check.id)
     // Run the check
     await githubOrgMFA(knex)
     // Check that the database has the expected results
-    results = await getAllResults(knex)
+    results = await getAllResults()
     expect(results.length).toBe(1)
     expect(results[0].status).toBe('passed')
-    alerts = await getAllAlerts(knex)
+    alerts = await getAllAlerts()
     expect(alerts.length).toBe(0)
-    tasks = await getAllTasks(knex)
+    tasks = await getAllTasks()
     expect(tasks.length).toBe(0)
   })
   test('Should add (alerts and tasks) and update results', async () => {
     // Prepare the Scenario
-    await addGithubOrg(knex, { login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id, two_factor_requirement_enabled: false })
-    await addResult(knex, { compliance_check_id: check.id, project_id: project.id, status: 'passed', rationale: 'failed previously', severity: 'critical' })
+    await addGithubOrg({ login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id, two_factor_requirement_enabled: false })
+    await addResult({ compliance_check_id: check.id, project_id: project.id, status: 'passed', rationale: 'failed previously', severity: 'critical' })
     // Check that the database has the expected results
-    let results = await getAllResults(knex)
+    let results = await getAllResults()
     expect(results.length).toBe(1)
     expect(results[0].compliance_check_id).toBe(check.id)
-    let alerts = await getAllAlerts(knex)
+    let alerts = await getAllAlerts()
     expect(alerts.length).toBe(0)
-    let tasks = await getAllTasks(knex)
+    let tasks = await getAllTasks()
     expect(tasks.length).toBe(0)
     // Run the check
     await githubOrgMFA(knex)
     // Check that the database has the expected results
-    results = await getAllResults(knex)
+    results = await getAllResults()
     expect(results.length).toBe(1)
     expect(results[0].status).toBe('failed')
     expect(results[0].rationale).not.toBe('failed previously')
-    alerts = await getAllAlerts(knex)
+    alerts = await getAllAlerts()
     expect(alerts.length).toBe(1)
     expect(alerts[0].compliance_check_id).toBe(check.id)
-    tasks = await getAllTasks(knex)
+    tasks = await getAllTasks()
     expect(tasks.length).toBe(1)
     expect(tasks[0].compliance_check_id).toBe(check.id)
   })

--- a/__tests__/checks/githubOrgMFA.test.js
+++ b/__tests__/checks/githubOrgMFA.test.js
@@ -39,8 +39,8 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  await resetDatabase(knex);
-  [project] = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
+  await resetDatabase(knex)
+  project = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
 })
 
 afterAll(async () => {

--- a/__tests__/checks/githubOrgMFA.test.js
+++ b/__tests__/checks/githubOrgMFA.test.js
@@ -33,7 +33,6 @@ beforeAll(async () => {
     addAlert,
     addTask,
     addResult,
-    getAllGithubOrganizations,
     getCheckByCodeName
   } = initializeStore(knex))
   check = await getCheckByCodeName('githubOrgMFA')

--- a/__tests__/checks/githubOrgMFA.test.js
+++ b/__tests__/checks/githubOrgMFA.test.js
@@ -20,7 +20,7 @@ let addProject,
   addAlert,
   addTask,
   addResult,
-  getCheckByCodeName;
+  getCheckByCodeName
 
 beforeAll(async () => {
   knex = knexInit(dbSettings);
@@ -34,8 +34,8 @@ beforeAll(async () => {
     addTask,
     addResult,
     getAllGithubOrganizations,
-    getCheckByCodeName,
-  } = initializeStore(knex));
+    getCheckByCodeName
+  } = initializeStore(knex))
   check = await getCheckByCodeName('githubOrgMFA')
 })
 

--- a/__tests__/checks/softwareDesignTraining.test.js
+++ b/__tests__/checks/softwareDesignTraining.test.js
@@ -26,7 +26,6 @@ beforeAll(async () => {
   knex = knexInit(dbSettings);
   ({
     addProject,
-    addGithubOrganization: addGithubOrg,
     addSSoftwareDesignTraining,
     getAllSSoftwareDesignTrainings,
     getAllResults,
@@ -35,7 +34,6 @@ beforeAll(async () => {
     addAlert,
     addTask,
     addResult,
-    getAllGithubOrganizations,
     getCheckByCodeName
   } = initializeStore(knex))
   check = await getCheckByCodeName('softwareDesignTraining')

--- a/__tests__/checks/softwareDesignTraining.test.js
+++ b/__tests__/checks/softwareDesignTraining.test.js
@@ -20,7 +20,7 @@ let addProject,
   addResult,
   getCheckByCodeName,
   addSSoftwareDesignTraining,
-  getAllSSoftwareDesignTrainings;
+  getAllSSoftwareDesignTrainings
 
 beforeAll(async () => {
   knex = knexInit(dbSettings);
@@ -36,8 +36,8 @@ beforeAll(async () => {
     addTask,
     addResult,
     getAllGithubOrganizations,
-    getCheckByCodeName,
-  } = initializeStore(knex));
+    getCheckByCodeName
+  } = initializeStore(knex))
   check = await getCheckByCodeName('softwareDesignTraining')
 })
 
@@ -66,7 +66,7 @@ describe('Integration: softwareDesignTraining', () => {
     // Run the check
     await expect(softwareDesignTraining(knex)).resolves.toBeUndefined()
     // Check that the database has the expected results
-    trainings = await getAllSSoftwareDesignTrainings();
+    trainings = await getAllSSoftwareDesignTrainings()
     expect(trainings.length).toBe(1)
     results = await getAllResults()
     expect(results.length).toBe(1)

--- a/__tests__/checks/softwareDesignTraining.test.js
+++ b/__tests__/checks/softwareDesignTraining.test.js
@@ -40,8 +40,8 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  await resetDatabase(knex);
-  [project] = await addProject({ name: 'project', category: 'impact' })
+  await resetDatabase(knex)
+  project = await addProject({ name: 'project', category: 'impact' })
 })
 
 afterAll(async () => {

--- a/__tests__/checks/softwareDesignTraining.test.js
+++ b/__tests__/checks/softwareDesignTraining.test.js
@@ -2,8 +2,7 @@ const knexInit = require('knex')
 const { getConfig } = require('../../src/config')
 const softwareDesignTraining = require('../../src/checks/complianceChecks/softwareDesignTraining')
 const {
-  resetDatabase, addProject, getAllResults, getAllTasks, getAllAlerts,
-  addAlert, addTask, addResult, getCheckByCodeName, addSSoftwareDesignTraining, getAllSoftwareDesignTrainings
+  resetDatabase, initializeStore
 } = require('../../__utils__')
 
 const { dbSettings } = getConfig('test')
@@ -12,14 +11,39 @@ let knex
 let project
 let check
 
+let addProject,
+  getAllResults,
+  getAllTasks,
+  getAllAlerts,
+  addAlert,
+  addTask,
+  addResult,
+  getCheckByCodeName,
+  addSSoftwareDesignTraining,
+  getAllSSoftwareDesignTrainings;
+
 beforeAll(async () => {
-  knex = knexInit(dbSettings)
-  check = await getCheckByCodeName(knex, 'softwareDesignTraining')
+  knex = knexInit(dbSettings);
+  ({
+    addProject,
+    addGithubOrganization: addGithubOrg,
+    addSSoftwareDesignTraining,
+    getAllSSoftwareDesignTrainings,
+    getAllResults,
+    getAllTasks,
+    getAllAlerts,
+    addAlert,
+    addTask,
+    addResult,
+    getAllGithubOrganizations,
+    getCheckByCodeName,
+  } = initializeStore(knex));
+  check = await getCheckByCodeName('softwareDesignTraining')
 })
 
 beforeEach(async () => {
-  await resetDatabase(knex)
-  project = await addProject(knex, { name: 'project', category: 'impact' })
+  await resetDatabase(knex);
+  [project] = await addProject({ name: 'project', category: 'impact' })
 })
 
 afterAll(async () => {
@@ -29,85 +53,85 @@ afterAll(async () => {
 describe('Integration: softwareDesignTraining', () => {
   test('Should add results without alerts or tasks', async () => {
     // Add a passed check scenario
-    await addSSoftwareDesignTraining(knex, { project_id: project.id, description: 'learning accomplished', training_date: new Date().toISOString() })
-    let trainings = await getAllSoftwareDesignTrainings(knex)
+    await addSSoftwareDesignTraining({ project_id: project.id, description: 'learning accomplished', training_date: new Date().toISOString() })
+    let trainings = await getAllSSoftwareDesignTrainings()
     expect(trainings.length).toBe(1)
     // Check that the database is empty
-    let results = await getAllResults(knex)
+    let results = await getAllResults()
     expect(results.length).toBe(0)
-    let alerts = await getAllAlerts(knex)
+    let alerts = await getAllAlerts()
     expect(alerts.length).toBe(0)
-    let tasks = await getAllTasks(knex)
+    let tasks = await getAllTasks()
     expect(tasks.length).toBe(0)
     // Run the check
     await expect(softwareDesignTraining(knex)).resolves.toBeUndefined()
     // Check that the database has the expected results
-    trainings = await getAllSoftwareDesignTrainings(knex)
+    trainings = await getAllSSoftwareDesignTrainings();
     expect(trainings.length).toBe(1)
-    results = await getAllResults(knex)
+    results = await getAllResults()
     expect(results.length).toBe(1)
     expect(results[0].status).toBe('passed')
     expect(results[0].compliance_check_id).toBe(check.id)
-    alerts = await getAllAlerts(knex)
+    alerts = await getAllAlerts()
     expect(alerts.length).toBe(0)
-    tasks = await getAllTasks(knex)
+    tasks = await getAllTasks()
     expect(tasks.length).toBe(0)
   })
   test('Should delete (previous alerts and tasks) and add results', async () => {
     // Add a passed check scenario
-    await addSSoftwareDesignTraining(knex, { project_id: project.id, description: 'learning accomplished', training_date: new Date().toISOString() })
+    await addSSoftwareDesignTraining({ project_id: project.id, description: 'learning accomplished', training_date: new Date().toISOString() })
     // Add previous alerts and tasks
-    await addAlert(knex, { compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
-    await addTask(knex, { compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    await addAlert({ compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    await addTask({ compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
     // Check that the database has the expected results
-    const trainings = await getAllSoftwareDesignTrainings(knex)
+    const trainings = await getAllSSoftwareDesignTrainings()
     expect(trainings.length).toBe(1)
-    let results = await getAllResults(knex)
+    let results = await getAllResults()
     expect(results.length).toBe(0)
-    let alerts = await getAllAlerts(knex)
+    let alerts = await getAllAlerts()
     expect(alerts.length).toBe(1)
     expect(alerts[0].compliance_check_id).toBe(check.id)
-    let tasks = await getAllTasks(knex)
+    let tasks = await getAllTasks()
     expect(tasks.length).toBe(1)
     expect(tasks[0].compliance_check_id).toBe(check.id)
     // Run the check
     await expect(softwareDesignTraining(knex)).resolves.toBeUndefined()
     // Check that the database has the expected results
-    results = await getAllResults(knex)
+    results = await getAllResults()
     expect(results.length).toBe(1)
     expect(results[0].status).toBe('passed')
     expect(results[0].compliance_check_id).toBe(check.id)
-    alerts = await getAllAlerts(knex)
+    alerts = await getAllAlerts()
     expect(alerts.length).toBe(0)
-    tasks = await getAllTasks(knex)
+    tasks = await getAllTasks()
     expect(tasks.length).toBe(0)
   })
   test('Should add (alerts and tasks) and update results', async () => {
-    await addResult(knex, { compliance_check_id: check.id, project_id: project.id, status: 'failed', rationale: 'failed previously', severity: 'critical' })
+    await addResult({ compliance_check_id: check.id, project_id: project.id, status: 'failed', rationale: 'failed previously', severity: 'critical' })
     // Check that the database is empty
-    let results = await getAllResults(knex)
+    let results = await getAllResults()
     expect(results.length).toBe(1)
     expect(results[0].compliance_check_id).toBe(check.id)
-    let trainings = await getAllSoftwareDesignTrainings(knex)
+    let trainings = await getAllSSoftwareDesignTrainings()
     expect(trainings.length).toBe(0)
-    let alerts = await getAllAlerts(knex)
+    let alerts = await getAllAlerts()
     expect(alerts.length).toBe(0)
-    let tasks = await getAllTasks(knex)
+    let tasks = await getAllTasks()
     expect(tasks.length).toBe(0)
     // Run the check
     await expect(softwareDesignTraining(knex)).resolves.toBeUndefined()
     // Check that the database has the expected results
-    results = await getAllResults(knex)
+    results = await getAllResults()
     expect(results.length).toBe(1)
     expect(results[0].status).toBe('failed')
     expect(results[0].rationale).not.toBe('failed previously')
     expect(results[0].compliance_check_id).toBe(check.id)
-    trainings = await getAllSoftwareDesignTrainings(knex)
+    trainings = await getAllSSoftwareDesignTrainings()
     expect(trainings.length).toBe(0)
-    alerts = await getAllAlerts(knex)
+    alerts = await getAllAlerts()
     expect(alerts.length).toBe(1)
     expect(alerts[0].compliance_check_id).toBe(check.id)
-    tasks = await getAllTasks(knex)
+    tasks = await getAllTasks()
     expect(tasks.length).toBe(1)
     expect(tasks[0].compliance_check_id).toBe(check.id)
   })

--- a/__tests__/cli/check.test.js
+++ b/__tests__/cli/check.test.js
@@ -15,7 +15,6 @@ beforeAll(() => {
   ({
     getAllComplianceChecks
   } = initializeStore(knex))
-
 })
 beforeEach(async () => {
   await resetDatabase(knex)

--- a/__tests__/cli/check.test.js
+++ b/__tests__/cli/check.test.js
@@ -3,14 +3,19 @@ const knexInit = require('knex')
 const { getConfig } = require('../../src/config')
 
 const { listCheckCommand } = require('../../src/cli')
-const { resetDatabase, getAllComplianceChecks } = require('../../__utils__')
+const { resetDatabase, initializeStore } = require('../../__utils__')
 
 const { dbSettings } = getConfig('test')
 
 let knex
+let getAllComplianceChecks
 
 beforeAll(() => {
-  knex = knexInit(dbSettings)
+  knex = knexInit(dbSettings);
+  ({
+    getAllComplianceChecks
+  } = initializeStore(knex))
+
 })
 beforeEach(async () => {
   await resetDatabase(knex)
@@ -25,7 +30,7 @@ describe('list - Non-Interactive Mode', () => {
   jest.spyOn(inquirer, 'prompt').mockImplementation(async () => ({}))
 
   test('Should provide a list of available workflows', async () => {
-    const checks = await getAllComplianceChecks(knex)
+    const checks = await getAllComplianceChecks()
     // Ensure that there are checks available
     expect(checks.length).not.toBe(0)
     // Filter relevant checks

--- a/__tests__/cli/workflows.test.js
+++ b/__tests__/cli/workflows.test.js
@@ -22,11 +22,11 @@ beforeAll(() => {
   ({
     getAllProjects,
     getAllGithubOrganizations: getAllGithubOrgs,
-    addGithubOrg,
+    addGithubOrganization: addGithubOrg,
     addProject,
     getAllGithubRepositories: getAllGithubRepos,
-    addGithubRepo
-  } = initializeStore(knex))
+    addGithubRepo,
+  } = initializeStore(knex));
 })
 beforeEach(async () => {
   await resetDatabase(knex)

--- a/__tests__/cli/workflows.test.js
+++ b/__tests__/cli/workflows.test.js
@@ -25,8 +25,8 @@ beforeAll(() => {
     addGithubOrg,
     addProject,
     getAllGithubRepositories: getAllGithubRepos,
-    addGithubRepo,
-  } = initializeStore(knex));
+    addGithubRepo
+  } = initializeStore(knex))
 })
 beforeEach(async () => {
   await resetDatabase(knex)

--- a/__tests__/cli/workflows.test.js
+++ b/__tests__/cli/workflows.test.js
@@ -25,8 +25,8 @@ beforeAll(() => {
     addGithubOrganization: addGithubOrg,
     addProject,
     getAllGithubRepositories: getAllGithubRepos,
-    addGithubRepo,
-  } = initializeStore(knex));
+    addGithubRepo
+  } = initializeStore(knex))
 })
 beforeEach(async () => {
   await resetDatabase(knex)

--- a/__tests__/cli/workflows.test.js
+++ b/__tests__/cli/workflows.test.js
@@ -74,7 +74,7 @@ describe('run update-github-orgs', () => {
 
   test('Should update the project with new information available', async () => {
     // Prepare the database
-    const [project] = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
+    const project = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
     await addGithubOrg({ login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id })
     const projects = await getAllProjects()
     expect(projects.length).toBe(1)
@@ -105,7 +105,7 @@ describe('run upsert-github-repositories', () => {
   })
   test('Should add the repositories related to the organization', async () => {
     // Prepare the database
-    const [project] = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
+    const project = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
     await addGithubOrg({ login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id })
     const projects = await getAllProjects()
     expect(projects.length).toBe(1)
@@ -123,8 +123,8 @@ describe('run upsert-github-repositories', () => {
     expect(githubRepos[0].description).toBe(sampleGithubRepository.description)
   })
   test('Should update the repositories related to the organization', async () => {
-    const [project] = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
-    const [org] = await addGithubOrg({ login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id })
+    const project = await addProject({ name: sampleGithubOrg.login, category: 'impact' })
+    const org = await addGithubOrg({ login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id })
     const githubRepoData = simplifyObject(sampleGithubRepository, {
       include: ['node_id', 'name', 'full_name', 'html_url', 'url', 'git_url', 'ssh_url', 'clone_url', 'visibility', 'default_branch']
     })

--- a/__utils__/index.js
+++ b/__utils__/index.js
@@ -12,4 +12,4 @@ const resetDatabase = async (knex) => {
 module.exports = {
   resetDatabase,
   initializeStore
-};
+}

--- a/__utils__/index.js
+++ b/__utils__/index.js
@@ -1,3 +1,4 @@
+const { initializeStore } = require('../src/store')
 const resetDatabase = async (knex) => {
   await knex.raw('TRUNCATE TABLE software_design_training RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE compliance_checks_results RESTART IDENTITY CASCADE')
@@ -8,78 +9,7 @@ const resetDatabase = async (knex) => {
   await knex.raw('TRUNCATE TABLE projects RESTART IDENTITY CASCADE')
 }
 
-const getAllProjects = (knex) => knex('projects').select('*')
-const getAllGithubOrgs = (knex) => knex('github_organizations').select('*')
-
-const addProject = async (knex, { name, category }) => {
-  const [project] = await knex('projects').insert({ name, category }).returning('*')
-  return project
-}
-
-const addGithubOrg = async (knex, data) => {
-  const [githubOrg] = await knex('github_organizations').insert(data).returning('*')
-  return githubOrg
-}
-
-const getAllGithubRepos = (knex) => knex('github_repositories').select('*')
-const addGithubRepo = async (knex, data) => {
-  const [githubRepo] = await knex('github_repositories').insert(data).returning('*')
-  return githubRepo
-}
-
-const getAllResults = (knex) => knex('compliance_checks_results').select('*')
-const getAllTasks = (knex) => knex('compliance_checks_tasks').select('*')
-const getAllAlerts = (knex) => knex('compliance_checks_alerts').select('*')
-const addAlert = async (knex, alert) => {
-  const [newAlert] = await knex('compliance_checks_alerts').insert(alert).returning('*')
-  return newAlert
-}
-
-const addTask = async (knex, task) => {
-  const [newTask] = await knex('compliance_checks_tasks').insert(task).returning('*')
-  return newTask
-}
-
-const addResult = async (knex, result) => {
-  const [newResult] = await knex('compliance_checks_results').insert(result).returning('*')
-  return newResult
-}
-
-const getAllComplianceChecks = (knex) => knex('compliance_checks').select('*')
-const getCheckByCodeName = async (knex, codeName) => {
-  const check = await knex('compliance_checks').where({ code_name: codeName }).first()
-  return check
-}
-
-const addSSoftwareDesignTraining = async (knex, data) => {
-  const [training] = await knex('software_design_training').insert(data).returning('*')
-  return training
-}
-
-const getAllSoftwareDesignTrainings = (knex) => knex('software_design_training').select('*')
-
-const addOSSFScorecardResult = async (knex, data) => {
-  const [result] = await knex('ossf_scorecard_results').insert(data).returning('*')
-  return result
-}
-
 module.exports = {
-  getAllComplianceChecks,
   resetDatabase,
-  getAllProjects,
-  getAllGithubOrgs,
-  addProject,
-  addGithubOrg,
-  getAllGithubRepos,
-  addGithubRepo,
-  getAllResults,
-  getAllTasks,
-  getAllAlerts,
-  addAlert,
-  addTask,
-  addResult,
-  getCheckByCodeName,
-  addSSoftwareDesignTraining,
-  getAllSoftwareDesignTrainings,
-  addOSSFScorecardResult
-}
+  initializeStore
+};

--- a/src/cli/project.js
+++ b/src/cli/project.js
@@ -88,7 +88,7 @@ async function runAddProjectCommand (knex, options = {}) {
 
   answers.githubUrls = Array.isArray(answers.githubUrls) ? answers.githubUrls : stringToArray(answers.githubUrls)
 
-  const [project] = await addProject({
+  const project = await addProject({
     name: answers.name.toLowerCase(),
     category: answers.category
   })

--- a/src/database/seeds/index.js
+++ b/src/database/seeds/index.js
@@ -16,8 +16,8 @@ exports.seed = async (knex) => {
     addProject,
     addGithubOrganization: addGithubOrg,
     addGithubRepo,
-    addOSSFScorecardResult,
-  } = initializeStore(knex);
+    addOSSFScorecardResult
+  } = initializeStore(knex)
 
   // Add a project
   const [project] = await addProject({

--- a/src/database/seeds/index.js
+++ b/src/database/seeds/index.js
@@ -20,16 +20,16 @@ exports.seed = async (knex) => {
   } = initializeStore(knex)
 
   // Add a project
-  const [project] = await addProject({
+  const project = await addProject({
     name: 'github',
     category: 'impact'
   })
 
   // Add a GitHub organization
-  const [githubOrg] = await addGithubOrg({ ...github.mappers.org(sampleGithubOrg), project_id: project.id })
+  const githubOrg = await addGithubOrg({ ...github.mappers.org(sampleGithubOrg), project_id: project.id })
 
   // Add GitHub repository
-  const [githubRepo] = await addGithubRepo({ ...github.mappers.repo(sampleGithubRepository), github_organization_id: githubOrg.id })
+  const githubRepo = await addGithubRepo({ ...github.mappers.repo(sampleGithubRepository), github_organization_id: githubOrg.id })
 
   // Add OSSF Scorecard results
   await addOSSFScorecardResult({ ...ossf.mappers.result(sampleOSSFScorecardResult), github_repository_id: githubRepo.id, analysis_execution_time: 19123 })

--- a/src/database/seeds/index.js
+++ b/src/database/seeds/index.js
@@ -5,29 +5,32 @@ const {
 } = require('../../../__fixtures__')
 const {
   resetDatabase,
-  addProject,
-  addGithubOrg,
-  addGithubRepo,
-  addOSSFScorecardResult
+  initializeStore
 } = require('../../../__utils__')
 const { github, ossf } = require('../../providers')
 
 exports.seed = async (knex) => {
   // Clean up the database
   await resetDatabase(knex)
+  const {
+    addProject,
+    addGithubOrganization: addGithubOrg,
+    addGithubRepo,
+    addOSSFScorecardResult,
+  } = initializeStore(knex);
 
   // Add a project
-  const project = await addProject(knex, {
+  const [project] = await addProject({
     name: 'github',
     category: 'impact'
   })
 
   // Add a GitHub organization
-  const githubOrg = await addGithubOrg(knex, { ...github.mappers.org(sampleGithubOrg), project_id: project.id })
+  const [githubOrg] = await addGithubOrg({ ...github.mappers.org(sampleGithubOrg), project_id: project.id })
 
   // Add GitHub repository
-  const githubRepo = await addGithubRepo(knex, { ...github.mappers.repo(sampleGithubRepository), github_organization_id: githubOrg.id })
+  const [githubRepo] = await addGithubRepo({ ...github.mappers.repo(sampleGithubRepository), github_organization_id: githubOrg.id })
 
   // Add OSSF Scorecard results
-  await addOSSFScorecardResult(knex, { ...ossf.mappers.result(sampleOSSFScorecardResult), github_repository_id: githubRepo.id, analysis_execution_time: 19123 })
+  await addOSSFScorecardResult({ ...ossf.mappers.result(sampleOSSFScorecardResult), github_repository_id: githubRepo.id, analysis_execution_time: 19123 })
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -121,26 +121,34 @@ const initializeStore = (knex) => {
   return {
     addProject: addProject(knex),
     addGithubOrganization: addGithubOrganization(knex),
-    getAllGithubOrganizations: () => getAll('github_organizations'),
     updateGithubOrganization: updateGithubOrganization(knex),
     upsertGithubRepository: upsertGithubRepository(knex),
+    getAllGithubOrganizations: () => getAll('github_organizations'),
     getAllComplianceChecks: () => getAll('compliance_checks'),
-    getCheckByCodeName: getCheckByCodeName(knex),
     getAllProjects: () => getAll('projects'),
+    getAllSSoftwareDesignTrainings: () => getAll('software_design_training'),
+    getAllGithubRepositories: () => getAll('github_repositories'),
+    getAllChecklists: () => getAll('compliance_checklists'),
+    getAllResults: () => getAll('compliance_checks_results'),
+    getAllTasks: () => getAll('compliance_checks_tasks'),
+    getAllAlerts: () => getAll('compliance_checks_alerts'),
+    getAllChecksInChecklistById,
+    getAllGithubOrganizationsByProjectsId: (projectIds) => getAllGithubOrganizationsByProjectsId(knex, projectIds),
+    getAllSSoftwareDesignTrainingsByProjectIds: (projectIds) => getAllSSoftwareDesignTrainingsByProjectIds(knex, projectIds),
+    getCheckByCodeName: getCheckByCodeName(knex),
     deleteTasksByComplianceCheckId: deleteTasksByComplianceCheckId(knex),
     deleteAlertsByComplianceCheckId: deleteAlertsByComplianceCheckId(knex),
     addAlert: (alert) => addTo('compliance_checks_alerts', alert),
     addTask: (task) => addTo('compliance_checks_tasks', task),
+    addResult: (result) => addTo('compliance_checks_results', result),
+    addSSoftwareDesignTraining: (data) => addTo('software_design_training', data),
+    addGithubRepo: (repo) => addTo('github_repositories', repo),
+    addGithubOrg: (org) => addTo('github_organizations', org),
     upsertComplianceCheckResult: upsertComplianceCheckResult(knex),
-    getAllSSoftwareDesignTrainings: () => getAll('software_design_training'),
-    getAllGithubRepositories: () => getAll('github_repositories'),
-    getAllChecklists: () => getAll('compliance_checklists'),
-    getAllChecksInChecklistById,
-    getAllGithubOrganizationsByProjectsId: (projectIds) => getAllGithubOrganizationsByProjectsId(knex, projectIds),
-    getAllSSoftwareDesignTrainingsByProjectIds: (projectIds) => getAllSSoftwareDesignTrainingsByProjectIds(knex, projectIds),
     upsertOSSFScorecard: upsertOSSFScorecard(knex)
   }
 }
+
 
 module.exports = {
   initializeStore

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,7 +7,7 @@ const getAllFn = knex => (table) => {
 
 const addFn = knex => (table, record) => {
   debug(`Inserting ${record} in ${table}`)
-  return knex(table).insert(record).returning('*')
+  return knex(table).insert(record).returning('*').then(results => results[0])
 }
 
 const upsertRecord = async ({ knex, table, uniqueCriteria, data }) => {
@@ -34,7 +34,7 @@ const addGithubOrganization = knex => async (organization) => {
     throw new Error(`Organization with login (${organization.login}) already exists`)
   }
   debug(`Inserting organization (${organization.login})...`)
-  return knex('github_organizations').insert(organization).returning('*')
+  return knex('github_organizations').insert(organization).returning('*').then(results => results[0])
 }
 
 const addProject = knex => async (project) => {
@@ -48,7 +48,7 @@ const addProject = knex => async (project) => {
   return knex('projects').insert({
     name,
     category
-  }).returning('*')
+  }).returning('*').then(results => results[0])
 }
 
 const getCheckByCodeName = knex => (codeName) => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -143,9 +143,9 @@ const initializeStore = (knex) => {
     addResult: (result) => addTo('compliance_checks_results', result),
     addSSoftwareDesignTraining: (data) => addTo('software_design_training', data),
     addGithubRepo: (repo) => addTo('github_repositories', repo),
-    addGithubOrg: (org) => addTo('github_organizations', org),
-    upsertComplianceCheckResult: upsertComplianceCheckResult(knex),
-    upsertOSSFScorecard: upsertOSSFScorecard(knex)
+    addOSSFScorecardResult: (ossf) => addTo('ossf_scorecard_results', ossf),
+    upsertOSSFScorecard: upsertOSSFScorecard(knex),
+    upsertComplianceCheckResult: upsertComplianceCheckResult(knex)
   }
 }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -149,7 +149,6 @@ const initializeStore = (knex) => {
   }
 }
 
-
 module.exports = {
   initializeStore
 }


### PR DESCRIPTION
### Main Changes

There were quite a few funcitonality duplicated both at src/store and __utils__, the latter used only in __tests__. Most of them were refactored, moved to be in src/store, leaving in __utils__ those ones related to destroy (reset) the database to make up the tests.

### Context

- Closes #158
- Closes #170

### Changelog
- 8f7a9d1 chore: refactor remaining database functions by @telekosmos 
- 0b4f591 chore: refactor tests update all of them to the `__utils__` refurbishment by @telekosmos
- c6fb95d chore: fix linting by @telekosmos
- be1dc4b chore: fix linting errors left behind :-/ by @telekosmos
- 343bc69 chore: fixing database seeding after store refactor by @telekosmos
- 33cc8c0 chore: make linting happy again by @telekosmos
- 28aa663 chore: refactor store to return the added object when addition occurs by @UlisesGascon