### PR TITLE
Add `version` CLI command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { Command } = require('commander')
+const pkg = require('./package.json')
 const { getConfig } = require('./src/config')
 const { dbSettings } = getConfig()
 const { logger } = require('./src/utils')
@@ -122,6 +123,14 @@ checklist
     } finally {
       await knex.destroy()
     }
+  })
+
+// @TODO: Include tests for this command
+program
+  .command('version')
+  .description('Show version information')
+  .action(() => {
+    logger.info(`${pkg.name}@${pkg.version} (${pkg.license})`)
   })
 
 program.parse(process.argv)


### PR DESCRIPTION
### Main Changes
- Add command `version` to CLI. This command showcase the info from the `package.json` (`name`, `version` and `license`) (7e520b1)

### Screenshots
![Screenshot from 2024-12-31 08-43-12](https://github.com/user-attachments/assets/3b473f6b-8559-442f-8320-7c3da3590fb2)

### Changelog

- 7e520b1 feat: add version CLI command by @UlisesGascon

