### PR TITLE
enable check `owaspTop10Training` in the database

### DIFF
--- a/src/database/migrations/20250108200012_update_check_owaspTop10Training.js
+++ b/src/database/migrations/20250108200012_update_check_owaspTop10Training.js
@@ -1,0 +1,19 @@
+exports.up = async (knex) => {
+  await knex('compliance_checks')
+    .where({ code_name: 'owaspTop10Training' })
+    .update({
+      implementation_status: 'completed',
+      implementation_type: 'manual',
+      implementation_details_reference: 'https://github.com/OpenPathfinder/visionBoard/issues/63'
+    })
+}
+
+exports.down = async (knex) => {
+  await knex('compliance_checks')
+    .where({ code_name: 'owaspTop10Training' })
+    .update({
+      implementation_status: 'pending',
+      implementation_type: null,
+      implementation_details_reference: null
+    })
+}


### PR DESCRIPTION
Related #63

I think it would be good to include in the contributing file how to generate a new migration.