### PR TITLE
Add check validator for `owaspTop10Training`

### DIFF
--- a/__tests__/checks/owaspTop10Training.test.js
+++ b/__tests__/checks/owaspTop10Training.test.js
@@ -1,0 +1,139 @@
+const knexInit = require('knex')
+const { getConfig } = require('../../src/config')
+const owaspTop10Training = require('../../src/checks/complianceChecks/owaspTop10Training')
+const {
+  resetDatabase, initializeStore
+} = require('../../__utils__')
+
+const { dbSettings } = getConfig('test')
+
+let knex
+let project
+let check
+
+let addProject,
+  addOwaspTraining,
+  getAllResults,
+  getAllTasks,
+  getAllAlerts,
+  addAlert,
+  addTask,
+  addResult,
+  getCheckByCodeName,
+  getAllOwaspTrainings
+
+beforeAll(async () => {
+  knex = knexInit(dbSettings);
+  ({
+    addProject,
+    addOwaspTraining,
+    getAllOwaspTrainings,
+    getAllResults,
+    getAllTasks,
+    getAllAlerts,
+    addAlert,
+    addTask,
+    addResult,
+    getCheckByCodeName
+  } = initializeStore(knex))
+  check = await getCheckByCodeName('owaspTop10Training')
+})
+
+beforeEach(async () => {
+  await resetDatabase(knex)
+  project = await addProject({ name: 'project' })
+})
+
+afterAll(async () => {
+  await knex.destroy()
+})
+
+describe('Integration: owaspTop10Training', () => {
+  test('Should add results without alerts or tasks', async () => {
+    // Add a passed check scenario
+    await addOwaspTraining({ project_id: project.id, description: 'learning accomplished', training_date: new Date().toISOString() })
+    let trainings = await getAllOwaspTrainings()
+    expect(trainings.length).toBe(1)
+    // Check that the database is empty
+    let results = await getAllResults()
+    expect(results.length).toBe(0)
+    let alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    let tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+    // Run the check
+    await expect(owaspTop10Training(knex)).resolves.toBeUndefined()
+    // Check that the database has the expected results
+    trainings = await getAllOwaspTrainings()
+    expect(trainings.length).toBe(1)
+    results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('passed')
+    expect(results[0].compliance_check_id).toBe(check.id)
+    alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+  })
+
+  test('Should delete (previous alerts and tasks) and add results', async () => {
+    // Add a passed check scenario
+    await addOwaspTraining({ project_id: project.id, description: 'learning accomplished', training_date: new Date().toISOString() })
+    // Add previous alerts and tasks
+    await addAlert({ compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    await addTask({ compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    // Check that the database has the expected results
+    const trainings = await getAllOwaspTrainings()
+    expect(trainings.length).toBe(1)
+    let results = await getAllResults()
+    expect(results.length).toBe(0)
+    let alerts = await getAllAlerts()
+    expect(alerts.length).toBe(1)
+    expect(alerts[0].compliance_check_id).toBe(check.id)
+    let tasks = await getAllTasks()
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].compliance_check_id).toBe(check.id)
+    // Run the check
+    await expect(owaspTop10Training(knex)).resolves.toBeUndefined()
+    // Check that the database has the expected results
+    results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('passed')
+    expect(results[0].compliance_check_id).toBe(check.id)
+    alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+  })
+
+  test('Should add (alerts and tasks) and update results', async () => {
+    await addResult({ compliance_check_id: check.id, project_id: project.id, status: 'failed', rationale: 'failed previously', severity: 'critical' })
+    // Check that the database is empty
+    let results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].compliance_check_id).toBe(check.id)
+    let trainings = await getAllOwaspTrainings()
+    expect(trainings.length).toBe(0)
+    let alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    let tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+    // Run the check
+    await expect(owaspTop10Training(knex)).resolves.toBeUndefined()
+    // Check that the database has the expected results
+    results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('failed')
+    expect(results[0].rationale).not.toBe('failed previously')
+    expect(results[0].compliance_check_id).toBe(check.id)
+
+    trainings = await getAllOwaspTrainings()
+    expect(trainings.length).toBe(0)
+    alerts = await getAllAlerts()
+    expect(alerts.length).toBe(1)
+    expect(alerts[0].compliance_check_id).toBe(check.id)
+    tasks = await getAllTasks()
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].compliance_check_id).toBe(check.id)
+  })
+})

--- a/__tests__/checks/validators.test.js
+++ b/__tests__/checks/validators.test.js
@@ -1,4 +1,4 @@
-const { githubOrgMFA, softwareDesignTraining, adminRepoCreationOnly } = require('../../src/checks/validators')
+const { githubOrgMFA, softwareDesignTraining, adminRepoCreationOnly, owaspTraining } = require('../../src/checks/validators')
 // @see: https://github.com/OpenPathfinder/visionBoard/issues/43
 describe('githubOrgMFA', () => {
   let organizations, check, projects
@@ -272,6 +272,156 @@ describe('softwareDesignTraining', () => {
           compliance_check_id: 1,
           severity: 'critical',
           title: 'Create a Software Design Training',
+          description: 'Check the details on https://example.com'
+        }
+      ]
+    })
+  })
+})
+
+describe('owaspTraining', () => {
+  let trainings, check, projects
+
+  beforeEach(() => {
+    trainings = [
+      {
+        project_id: 1,
+        training_date: new Date().toISOString()
+      },
+      {
+        project_id: 2,
+        training_date: new Date().toISOString()
+      }
+    ]
+
+    check = {
+      id: 1,
+      default_priority_group: 'P1',
+      details_url: 'https://example.com'
+    }
+
+    projects = [
+      {
+        id: 1
+      },
+      {
+        id: 2
+      }
+    ]
+  })
+
+  it('Should generate a passed result if the project has a software design training and it is up to date', () => {
+    const analysis = owaspTraining({ trainings, check, projects })
+    expect(analysis).toEqual({
+      alerts: [],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'passed',
+          rationale: 'Owasp Top 10 Training is up to date'
+        },
+        {
+          project_id: 2,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'passed',
+          rationale: 'Owasp Top 10 Training is up to date'
+        }
+      ],
+      tasks: []
+    })
+  })
+  it('Should generate a failed result if the project has a software design training but it is out of date', () => {
+    trainings[0].training_date = '2019-01-01'
+    const analysis = owaspTraining({ trainings, check, projects })
+    expect(analysis).toEqual({
+      alerts: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'Owasp Top 10 Training is out of date',
+          description: 'Check the details on https://example.com'
+        }
+      ],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'failed',
+          rationale: 'Owasp Top 10 Training is out of date'
+        },
+        {
+          project_id: 2,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'passed',
+          rationale: 'Owasp Top 10 Training is up to date'
+        }
+      ],
+      tasks: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'Update Owasp Top 10 Training',
+          description: 'Check the details on https://example.com'
+        }
+      ]
+    })
+  })
+  it('Should generate a failed result if the project does not have a software design training', () => {
+    trainings = []
+    const analysis = owaspTraining({ trainings, check, projects })
+    expect(analysis).toEqual({
+      alerts: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'No Owasp Top 10 Training found',
+          description: 'Check the details on https://example.com'
+        },
+        {
+          project_id: 2,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'No Owasp Top 10 Training found',
+          description: 'Check the details on https://example.com'
+        }
+      ],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'failed',
+          rationale: 'No Owasp Top 10 Training found'
+        },
+        {
+          project_id: 2,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'failed',
+          rationale: 'No Owasp Top 10 Training found'
+        }
+      ],
+      tasks: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'Create a Owasp Top 10 Training',
+          description: 'Check the details on https://example.com'
+        },
+        {
+          project_id: 2,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'Create a Owasp Top 10 Training',
           description: 'Check the details on https://example.com'
         }
       ]

--- a/__utils__/index.js
+++ b/__utils__/index.js
@@ -1,6 +1,7 @@
 const { initializeStore } = require('../src/store')
 const resetDatabase = async (knex) => {
   await knex.raw('TRUNCATE TABLE software_design_training RESTART IDENTITY CASCADE')
+  await knex.raw('TRUNCATE TABLE owasp_training RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE compliance_checks_results RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE compliance_checks_tasks RESTART IDENTITY CASCADE')
   await knex.raw('TRUNCATE TABLE compliance_checks_alerts RESTART IDENTITY CASCADE')

--- a/src/checks/complianceChecks/owaspTop10Training.js
+++ b/src/checks/complianceChecks/owaspTop10Training.js
@@ -1,0 +1,31 @@
+const validators = require('../validators')
+const { initializeStore } = require('../../store')
+const debug = require('debug')('checks:softwareDesignTraining')
+
+module.exports = async (knex, { projects } = {}) => {
+  const {
+    getAllOwaspTrainingsByProjectIds, getCheckByCodeName,
+    getAllProjects, addAlert, addTask, upsertComplianceCheckResult,
+    deleteAlertsByComplianceCheckId, deleteTasksByComplianceCheckId
+  } = initializeStore(knex)
+  debug('Collecting relevant data...')
+  const check = await getCheckByCodeName('owaspTop10Training')
+
+  if (!projects || (Array.isArray(projects) && projects.length === 0)) {
+    projects = await getAllProjects()
+  }
+  const trainings = await getAllOwaspTrainingsByProjectIds(projects.map(project => project.id))
+
+  debug('Extracting the validation results...')
+  const analysis = validators.owaspTraining({ trainings, check, projects })
+  debug('Deleting previous alerts and tasks to avoid orphaned records...')
+  await deleteAlertsByComplianceCheckId(check.id)
+  await deleteTasksByComplianceCheckId(check.id)
+
+  debug('Upserting the new results...')
+  await Promise.all(analysis.results.map(result => upsertComplianceCheckResult(result)))
+
+  debug('Inserting the new Alerts and Tasks...')
+  await Promise.all(analysis.alerts.map(alert => addAlert(alert)))
+  await Promise.all(analysis.tasks.map(task => addTask(task)))
+}

--- a/src/checks/validators/index.js
+++ b/src/checks/validators/index.js
@@ -1,10 +1,12 @@
 const githubOrgMFA = require('./githubOrgMFA')
 const softwareDesignTraining = require('./softwareDesignTraining')
+const owaspTraining = require('./owaspTraining')
 const adminRepoCreationOnly = require('./adminRepoCreationOnly')
 
 const validators = {
   githubOrgMFA,
   softwareDesignTraining,
+  owaspTraining,
   adminRepoCreationOnly
 }
 

--- a/src/checks/validators/owaspTraining.js
+++ b/src/checks/validators/owaspTraining.js
@@ -1,0 +1,64 @@
+const debug = require('debug')('checks:validator:owaspTraining')
+const { getSeverityFromPriorityGroup, isDateWithinPolicy } = require('../../utils')
+
+const expirationPolicy = '6m'
+
+module.exports = ({ trainings = [], check, projects = [] }) => {
+  debug('Validating Owasp Top 10 Training...')
+  const alerts = []
+  const results = []
+  const tasks = []
+
+  debug('Processing Projects...')
+  projects.forEach(project => {
+    const baseData = {
+      project_id: project.id,
+      compliance_check_id: check.id,
+      severity: getSeverityFromPriorityGroup(check.default_priority_group)
+    }
+
+    const result = { ...baseData }
+    const task = { ...baseData }
+    const alert = { ...baseData }
+
+    const trainingDetails = trainings.find(training => training.project_id === project.id)
+
+    if (!trainingDetails) {
+      result.status = 'failed'
+      result.rationale = 'No Owasp Top 10 Training found'
+      alert.title = 'No Owasp Top 10 Training found'
+      alert.description = `Check the details on ${check.details_url}`
+      task.title = 'Create a Owasp Top 10 Training'
+      task.description = `Check the details on ${check.details_url}`
+    } else if (trainingDetails?.training_date && !isDateWithinPolicy(trainingDetails.training_date, expirationPolicy)) {
+      result.status = 'failed'
+      result.rationale = 'Owasp Top 10 Training is out of date'
+      alert.title = 'Owasp Top 10 Training is out of date'
+      alert.description = `Check the details on ${check.details_url}`
+      task.title = 'Update Owasp Top 10 Training'
+      task.description = `Check the details on ${check.details_url}`
+    } else {
+      result.status = 'passed'
+      result.rationale = 'Owasp Top 10 Training is up to date'
+    }
+    // Include only the task if was populated
+    if (Object.keys(task).length > Object.keys(baseData).length) {
+      debug(`Adding task for project (${project.id})`)
+      tasks.push(task)
+    }
+    // Include only the alert if was populated
+    if (Object.keys(alert).length > Object.keys(baseData).length) {
+      debug(`Adding alert for project (${project.id})`)
+      alerts.push(alert)
+    }
+    // Always include the result
+    results.push(result)
+    debug(`Processed project (${project.id})`)
+  })
+
+  return {
+    alerts,
+    results,
+    tasks
+  }
+}

--- a/src/database/migrations/20250109185855_add_owasp_training.js
+++ b/src/database/migrations/20250109185855_add_owasp_training.js
@@ -1,0 +1,34 @@
+exports.up = async (knex) => {
+  await knex.schema.createTable('owasp_training', (table) => {
+    table.increments('id').primary() // Primary key
+    table.string('training_date').defaultTo(knex.fn.now()).notNullable()
+
+    // Timestamps
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable()
+    table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable()
+
+     // Foreign key to 'projects' table
+     table.integer('project_id')
+       .notNullable()
+       .unsigned()
+       .references('id')
+       .inTable('projects')
+       .onDelete('CASCADE') // Deletes organization if the project is deleted
+       .onUpdate('CASCADE') // Updates organization if the project ID is updated
+  })
+
+  // Add trigger to automatically update the 'updated_at' column
+  await knex.raw(`
+    CREATE TRIGGER set_updated_at_owasp_training
+    BEFORE UPDATE ON owasp_training
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+  `)
+};
+
+exports.down = async (knex) => {
+    // Drop trigger
+    await knex.raw('DROP TRIGGER IF EXISTS set_updated_at_owasp_training ON owasp_training;')
+    // Drop table
+    await knex.schema.dropTableIfExists('owasp_training')
+};

--- a/src/database/migrations/20250109185855_add_owasp_training.js
+++ b/src/database/migrations/20250109185855_add_owasp_training.js
@@ -1,20 +1,22 @@
 exports.up = async (knex) => {
   await knex.schema.createTable('owasp_training', (table) => {
     table.increments('id').primary() // Primary key
+    table.text('description').notNullable()
+    table.enum('implementation_status', ['unknown', 'pending', 'completed']).notNullable().defaultTo('pending')
     table.string('training_date').defaultTo(knex.fn.now()).notNullable()
 
     // Timestamps
     table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable()
     table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable()
 
-     // Foreign key to 'projects' table
-     table.integer('project_id')
-       .notNullable()
-       .unsigned()
-       .references('id')
-       .inTable('projects')
-       .onDelete('CASCADE') // Deletes organization if the project is deleted
-       .onUpdate('CASCADE') // Updates organization if the project ID is updated
+    // Foreign key to 'projects' table
+    table.integer('project_id')
+      .notNullable()
+      .unsigned()
+      .references('id')
+      .inTable('projects')
+      .onDelete('CASCADE') // Deletes organization if the project is deleted
+      .onUpdate('CASCADE') // Updates organization if the project ID is updated
   })
 
   // Add trigger to automatically update the 'updated_at' column
@@ -24,11 +26,11 @@ exports.up = async (knex) => {
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
   `)
-};
+}
 
 exports.down = async (knex) => {
-    // Drop trigger
-    await knex.raw('DROP TRIGGER IF EXISTS set_updated_at_owasp_training ON owasp_training;')
-    // Drop table
-    await knex.schema.dropTableIfExists('owasp_training')
-};
+  // Drop trigger
+  await knex.raw('DROP TRIGGER IF EXISTS set_updated_at_owasp_training ON owasp_training;')
+  // Drop table
+  await knex.schema.dropTableIfExists('owasp_training')
+}

--- a/src/database/schema/schema.sql
+++ b/src/database/schema/schema.sql
@@ -645,10 +645,13 @@ ALTER SEQUENCE public.ossf_scorecard_results_id_seq OWNED BY public.ossf_scoreca
 
 CREATE TABLE public.owasp_training (
     id integer NOT NULL,
+    description text NOT NULL,
+    implementation_status text DEFAULT 'pending'::text NOT NULL,
     training_date character varying(255) DEFAULT CURRENT_TIMESTAMP NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    project_id integer NOT NULL
+    project_id integer NOT NULL,
+    CONSTRAINT owasp_training_implementation_status_check CHECK ((implementation_status = ANY (ARRAY['unknown'::text, 'pending'::text, 'completed'::text])))
 );
 
 

--- a/src/database/schema/schema.sql
+++ b/src/database/schema/schema.sql
@@ -640,6 +640,39 @@ ALTER SEQUENCE public.ossf_scorecard_results_id_seq OWNED BY public.ossf_scoreca
 
 
 --
+-- Name: owasp_training; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.owasp_training (
+    id integer NOT NULL,
+    training_date character varying(255) DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    project_id integer NOT NULL
+);
+
+
+--
+-- Name: owasp_training_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.owasp_training_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: owasp_training_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.owasp_training_id_seq OWNED BY public.owasp_training.id;
+
+
+--
 -- Name: projects; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -785,6 +818,13 @@ ALTER TABLE ONLY public.ossf_scorecard_results ALTER COLUMN id SET DEFAULT nextv
 
 
 --
+-- Name: owasp_training id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owasp_training ALTER COLUMN id SET DEFAULT nextval('public.owasp_training_id_seq'::regclass);
+
+
+--
 -- Name: projects id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -927,6 +967,14 @@ ALTER TABLE ONLY public.ossf_scorecard_results
 
 
 --
+-- Name: owasp_training owasp_training_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owasp_training
+    ADD CONSTRAINT owasp_training_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1003,6 +1051,13 @@ CREATE TRIGGER set_updated_at_github_repositories BEFORE UPDATE ON public.github
 --
 
 CREATE TRIGGER set_updated_at_ossf_scorecard_results BEFORE UPDATE ON public.ossf_scorecard_results FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+
+--
+-- Name: owasp_training set_updated_at_owasp_training; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_updated_at_owasp_training BEFORE UPDATE ON public.owasp_training FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
 
 
 --
@@ -1105,6 +1160,14 @@ ALTER TABLE ONLY public.github_repositories
 
 ALTER TABLE ONLY public.ossf_scorecard_results
     ADD CONSTRAINT ossf_scorecard_results_github_repository_id_foreign FOREIGN KEY (github_repository_id) REFERENCES public.github_repositories(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: owasp_training owasp_training_project_id_foreign; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.owasp_training
+    ADD CONSTRAINT owasp_training_project_id_foreign FOREIGN KEY (project_id) REFERENCES public.projects(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -116,6 +116,13 @@ const getAllSSoftwareDesignTrainingsByProjectIds = (knex, projectIds) => {
     .select('*')
 }
 
+const getAllOwaspTrainingsByProjectIds = (knex, projectIds) => {
+  debug(`Fetching all owasp trainings by project ids (${projectIds})...`)
+  return knex('owasp_training')
+    .whereIn('owasp_training.project_id', projectIds)
+    .select('*')
+}
+
 const initializeStore = (knex) => {
   debug('Initializing store...')
   const getAll = getAllFn(knex)
@@ -129,6 +136,7 @@ const initializeStore = (knex) => {
     getAllComplianceChecks: () => getAll('compliance_checks'),
     getAllProjects: () => getAll('projects'),
     getAllSSoftwareDesignTrainings: () => getAll('software_design_training'),
+    getAllOwaspTrainings: () => getAll('owasp_training'),
     getAllGithubRepositories: () => getAll('github_repositories'),
     getAllChecklists: () => getAll('compliance_checklists'),
     getAllResults: () => getAll('compliance_checks_results'),
@@ -137,6 +145,7 @@ const initializeStore = (knex) => {
     getAllChecksInChecklistById,
     getAllGithubOrganizationsByProjectsId: (projectIds) => getAllGithubOrganizationsByProjectsId(knex, projectIds),
     getAllSSoftwareDesignTrainingsByProjectIds: (projectIds) => getAllSSoftwareDesignTrainingsByProjectIds(knex, projectIds),
+    getAllOwaspTrainingsByProjectIds: (projectIds) => getAllOwaspTrainingsByProjectIds(knex, projectIds),
     getCheckByCodeName: getCheckByCodeName(knex),
     deleteTasksByComplianceCheckId: deleteTasksByComplianceCheckId(knex),
     deleteAlertsByComplianceCheckId: deleteAlertsByComplianceCheckId(knex),
@@ -144,6 +153,7 @@ const initializeStore = (knex) => {
     addTask: (task) => addTo('compliance_checks_tasks', task),
     addResult: (result) => addTo('compliance_checks_results', result),
     addSSoftwareDesignTraining: (data) => addTo('software_design_training', data),
+    addOwaspTraining: (data) => addTo('owasp_training', data),
     addGithubRepo: (repo) => addTo('github_repositories', repo),
     addOSSFScorecardResult: (ossf) => addTo('ossf_scorecard_results', ossf),
     upsertOSSFScorecard: upsertOSSFScorecard(knex),


### PR DESCRIPTION
The `owaspTraining` table is added, along with the check validators for `owaspTraining` and their respective tests.  

I would have preferred to create the table in one PR and the validators in another separate one, but due to time constraints, it was better for me to do everything in one. I understand this makes it harder to review.

Related #63