### PR TITLE
Add workflow `bulk-import`

### DIFF
--- a/__fixtures__/index.js
+++ b/__fixtures__/index.js
@@ -909,9 +909,17 @@ const sampleOSSFScorecardResult = {
   metadata: null
 }
 
+const sampleBulkImportFileContent = [{
+  type: 'softwareDesignTraining',
+  description: 'Course on software design principles done by the team',
+  project_id: 1,
+  implementation_status: 'completed'
+}]
+
 module.exports = {
   sampleGithubOrg,
   sampleGithubListOrgRepos,
   sampleGithubRepository,
-  sampleOSSFScorecardResult
+  sampleOSSFScorecardResult,
+  sampleBulkImportFileContent
 }

--- a/__tests__/cli/__snapshots__/workflows.test.js.snap
+++ b/__tests__/cli/__snapshots__/workflows.test.js.snap
@@ -32,5 +32,10 @@ exports[`list - Non-Interactive Mode Should provide a list of available workflow
     "name": "generate-reports",
     "workflow": [Function],
   },
+  {
+    "description": "Bulk import data from a CSV file.",
+    "name": "bulk-import",
+    "workflow": [Function],
+  },
 ]
 `;

--- a/__tests__/cli/workflows.test.js
+++ b/__tests__/cli/workflows.test.js
@@ -157,3 +157,10 @@ describe('run run-all-checks', () => {
 describe('run upsert-ossf-scorecard', () => {
   test.todo('Should upsert the OSSF Scorecard scoring by running and checking every repository in the database')
 })
+
+describe('run bulk-import', () => {
+  test.todo('Should bulk import data from a JSON file')
+  test.todo('Should throw an error when the file path is not provided')
+  test.todo('Should throw an error when the JSON file can\'t be parsed')
+  test.todo('Should throw an error when the JSON file is not valid due schema validation')
+})

--- a/__tests__/schemas.test.js
+++ b/__tests__/schemas.test.js
@@ -1,5 +1,5 @@
-const { sampleGithubOrg, sampleGithubListOrgRepos, sampleGithubRepository, sampleOSSFScorecardResult } = require('../__fixtures__')
-const { validateGithubOrg, validateGithubListOrgRepos, validateGithubRepository, validateOSSFResult } = require('../src/schemas')
+const { sampleGithubOrg, sampleGithubListOrgRepos, sampleGithubRepository, sampleOSSFScorecardResult, sampleBulkImportFileContent } = require('../__fixtures__')
+const { validateGithubOrg, validateGithubListOrgRepos, validateGithubRepository, validateOSSFResult, validateBulkImport } = require('../src/schemas')
 
 describe('schemas', () => {
   describe('validateGithubOrg', () => {
@@ -66,6 +66,19 @@ describe('schemas', () => {
     test('Should throw an error with invalid data', () => {
       const invalidData = { ...sampleOSSFScorecardResult, score: '123' }
       expect(() => validateOSSFResult(invalidData)).toThrow()
+    })
+  })
+  describe('validateBulkImport', () => {
+    test('Should not throw an error with valid data', () => {
+      expect(() => validateBulkImport(sampleBulkImportFileContent)).not.toThrow()
+    })
+
+    test('Should throw an error with invalid data', () => {
+      const invalidData = [
+        ...sampleBulkImportFileContent,
+        { ...sampleBulkImportFileContent[0], type: 'invalidType' }
+      ]
+      expect(() => validateBulkImport(invalidData)).toThrow()
     })
   })
 })

--- a/src/importers/index.js
+++ b/src/importers/index.js
@@ -1,0 +1,51 @@
+const { logger } = require('../utils')
+const { validateBulkImport } = require('../schemas')
+const { initializeStore } = require('../store')
+const { simplifyObject } = require('@ulisesgascon/simplify-object')
+const fs = require('fs')
+
+const bulkImport = async (knex, filePath) => {
+  logger.info('Bulk importing data...')
+  const { upsertSoftwareDesignTraining } = initializeStore(knex)
+
+  if (!fs.existsSync(filePath)) {
+    logger.error(`File not found: ${filePath}`)
+    throw new Error('File not found')
+  }
+  // Try to read the file
+  let data
+  try {
+    data = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (error) {
+    logger.info('Check the documentation for the expected file format in https://openpathfinder.com/docs/visionBoard/importers')
+    logger.error(`Error reading file: ${error.message}`)
+    throw error
+  }
+
+  // Validate the data
+  try {
+    validateBulkImport(data)
+  } catch (error) {
+    logger.info('Check the data schema in https://github.com/OpenPathfinder/visionBoard/blob/main/src/schemas/bulkImport.json')
+    logger.error('Error validating the data')
+    throw error
+  }
+
+  validateBulkImport(data)
+
+  // Update de database
+  for await (const item of data) {
+    if (item.type === 'softwareDesignTraining') {
+      logger.info('Upserting software design training data...')
+      await upsertSoftwareDesignTraining(simplifyObject(item, {
+        exclude: ['type']
+      }))
+    }
+  }
+
+  logger.info('Bulk importing completed')
+}
+
+module.exports = {
+  bulkImport
+}

--- a/src/schemas/bulkImport.json
+++ b/src/schemas/bulkImport.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": ["softwareDesignTraining"]
+      },
+      "description": {
+        "type": "string"
+      },
+      "project_id": {
+        "type": "integer"
+      },
+      "implementation_status": {
+        "type": "string",
+        "enum": ["unknown", "pending", "completed"]
+      },
+      "training_date": {
+        "type": "string",
+        "format": "date",
+        "nullable": true
+      }
+    },
+    "required": ["type", "description", "project_id", "implementation_status"],
+    "additionalProperties": false
+  }
+}

--- a/src/schemas/index.js
+++ b/src/schemas/index.js
@@ -4,6 +4,7 @@ const githubOrganizationSchema = require('./githubOrganization.json')
 const githubListOrgReposSchema = require('./githubListOrgRepos.json')
 const githubRepositorySchema = require('./githubRepository.json')
 const ossfScorecardResultSchema = require('./ossfScorecardResult.json')
+const bulkImportSchema = require('./bulkImport.json')
 
 const ajv = new Ajv()
 addFormats(ajv)
@@ -50,9 +51,20 @@ const validateOSSFResult = (data) => {
   return null
 }
 
+const validateBulkImport = (data) => {
+  const validate = ajv.compile(bulkImportSchema)
+  const valid = validate(data)
+  if (!valid) {
+    const readableErrors = getReadableErrors(validate)
+    throw new Error(`Error when validating the bulk import data: ${readableErrors}`)
+  }
+  return null
+}
+
 module.exports = {
   validateGithubOrg,
   validateGithubListOrgRepos,
   validateGithubRepository,
-  validateOSSFResult
+  validateOSSFResult,
+  validateBulkImport
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -92,6 +92,15 @@ const upsertGithubRepository = (knex) => (repository, orgId) => upsertRecord({
   data: { ...repository, github_organization_id: orgId }
 })
 
+const upsertSoftwareDesignTraining = (knex) => (data) => upsertRecord({
+  table: 'software_design_training',
+  knex,
+  uniqueCriteria: {
+    project_id: data.project_id
+  },
+  data
+})
+
 const getAllChecksInChecklistById = (knex, checklistId) =>
   debug(`Fetching all checks in checklist by id (${checklistId})...`) ||
   knex('checklist_items')
@@ -148,6 +157,7 @@ const initializeStore = (knex) => {
     addOSSFScorecardResult: (ossf) => addTo('ossf_scorecard_results', ossf),
     upsertOSSFScorecard: upsertOSSFScorecard(knex),
     upsertComplianceCheckResult: upsertComplianceCheckResult(knex),
+    upsertSoftwareDesignTraining: upsertSoftwareDesignTraining(knex),
     getAllOSSFResults: () => getAll('ossf_scorecard_results')
   }
 }

--- a/visionboard.js
+++ b/visionboard.js
@@ -40,6 +40,7 @@ workflow
   .command('run')
   .description('Run a workflow')
   .option('--name <name>', 'Name of the workflow')
+  .option('--file <file>', 'Input file for the workflow')
   .action(async (options) => {
     try {
       await runWorkflowCommand(knex, options)


### PR DESCRIPTION
### Main Changes
- Add workflow `bulk-import` (9cfe16a)


### Other Changes
- Add optional CLI argument `file` when running workflows (92ccae1)
- Extend store to support `upsertSoftwareDesignTraining` (490d07c)
- eAdd schema to validate bulk import operations (e970e2d)

### Context

- Closes https://github.com/OpenPathfinder/visionBoard/issues/56

### Screenshots

**Success**
![Screenshot from 2025-01-20 16-27-30](https://github.com/user-attachments/assets/b543381d-19de-4e99-920c-8469aec7b71c)

**Error in file path**
![Screenshot from 2025-01-20 16-27-53](https://github.com/user-attachments/assets/604ee3a6-adaa-4aca-a77c-43da2f950e74)

**Error with the JSON Schemas**
![Screenshot from 2025-01-20 16-28-26](https://github.com/user-attachments/assets/0f359ab7-56c6-4058-9973-34c069c8a64e)


### Changelog


- 92ccae1 feat: add optional CLI argument `file` when running workflows by @UlisesGascon
- 490d07c feat: extend store to support `upsertSoftwareDesignTraining` by @UlisesGascon
- e970e2d feat: add schema to validate bulk import operations by @UlisesGascon
- 9cfe16a feat: add workflow `bulk-import` by @UlisesGascon

