### PR TITLE
fix: migration rollback by truncating dependent table first

### DIFF
--- a/src/database/migrations/1737629113552_populate_compliance_check_resources.js
+++ b/src/database/migrations/1737629113552_populate_compliance_check_resources.js
@@ -1409,6 +1409,6 @@ exports.up = async (knex) => {
 }
 
 exports.down = async (knex) => {
-  await knex('compliance_checks_resources').truncate()
   await knex('resources_for_compliance_checks').truncate()
+  await knex('compliance_checks_resources').truncate()
 }


### PR DESCRIPTION
Ensure `resources_for_compliance_checks` is truncated before `compliance_checks_resources` to avoid foreign key constraint issues during rollback.