### PR TITLE
fix: ensure that the high an medium alerts are render in yellow

### DIFF
--- a/src/reports/templates/project.html.ejs
+++ b/src/reports/templates/project.html.ejs
@@ -43,8 +43,7 @@
             <% alerts.forEach(alert => { %>
               <li class="p-4 border-l-4 
                   <% if (alert.severity === 'critical') { %> border-red-600 bg-red-50 <% } %>
-                  <% if (alert.severity === 'warning') { %> border-yellow-600 bg-yellow-50 <% } %>
-                  <% if (alert.severity === 'info') { %> border-blue-600 bg-blue-50 <% } %>
+                  <% if (alert.severity === 'high' || alert.severity === 'medium' ) { %> border-yellow-600 bg-yellow-50 <% } %>
                   rounded-md shadow">
                 <h3 class="text-lg font-semibold">
                   <%= alert.title %>


### PR DESCRIPTION
### Main Changes

Ensure that the high an medium alerts are render in yellow


### Context

Related #195 

### Screenshots

**Before**

![Screenshot from 2025-02-12 17-04-33](https://github.com/user-attachments/assets/d3aae7ad-9785-4718-9e51-fcf09c7cf078)

**After**

![Screenshot from 2025-02-12 17-04-44](https://github.com/user-attachments/assets/24830b0f-8f9d-4105-a024-2f0196cc23f9)
