### PR TITLE
Scan in commits check

### DIFF
--- a/__tests__/checks/scanCommitsForSensitiveInfo.test.js
+++ b/__tests__/checks/scanCommitsForSensitiveInfo.test.js
@@ -1,0 +1,259 @@
+const knexInit = require('knex')
+const { getConfig } = require('../../src/config')
+const scanCommitsForSensitiveInfo = require('../../src/checks/complianceChecks/scanCommitsForSensitiveInfo')
+const {
+  resetDatabase, initializeStore, generateGithubRepoData
+} = require('../../__utils__')
+const { sampleGithubOrg } = require('../../__fixtures__')
+
+const { dbSettings } = getConfig('test')
+
+let knex,
+  project,
+  check,
+  addProject,
+  addGithubOrg,
+  addGithubRepo,
+  getAllResults,
+  getAllTasks,
+  getAllAlerts,
+  addAlert,
+  addTask,
+  addResult,
+  getCheckByCodeName
+
+beforeAll(async () => {
+  knex = knexInit(dbSettings);
+  ({
+    addProject,
+    addGithubOrganization: addGithubOrg,
+    addGithubRepo,
+    getAllResults,
+    getAllTasks,
+    getAllAlerts,
+    addAlert,
+    addTask,
+    addResult,
+    getCheckByCodeName
+  } = initializeStore(knex))
+  check = await getCheckByCodeName('scanCommitsForSensitiveInfo')
+})
+
+beforeEach(async () => {
+  await resetDatabase(knex)
+  project = await addProject({ name: sampleGithubOrg.login })
+})
+
+afterAll(async () => {
+  await knex.destroy()
+})
+
+describe('Integration: scanCommitsForSensitiveInfo', () => {
+  it('Should add results with no alerts or tasks on passed check', async () => {
+    // Add a passed check scenario
+    const org = await addGithubOrg({
+      login: sampleGithubOrg.login,
+      html_url: sampleGithubOrg.html_url,
+      project_id: project.id,
+      secret_scanning_enabled_for_new_repositories: true,
+      secret_scanning_push_protection_enabled_for_new_repositories: true
+    })
+    const repoData = generateGithubRepoData({
+      org,
+      name: 'repo1',
+      secret_scanning_status: 'enabled',
+      secret_scanning_push_protection_status: 'enabled',
+      secret_scanning_non_provider_patterns_status: 'enabled'
+    })
+    await addGithubRepo(repoData)
+
+    // Check that the database is empty
+    let results = await getAllResults()
+    expect(results.length).toBe(0)
+    let alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    let tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+    // Run the check
+    await expect(scanCommitsForSensitiveInfo(knex)).resolves.toBeUndefined()
+    // Check that the database has the expected results
+    results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('passed')
+    expect(results[0].compliance_check_id).toBe(check.id)
+    alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+  })
+
+  it('Should (hard) delete previous alerts and tasks and add new results on passed check', async () => {
+    // Prepare the Scenario
+    const org = await addGithubOrg({
+      login: sampleGithubOrg.login,
+      html_url: sampleGithubOrg.html_url,
+      project_id: project.id,
+      secret_scanning_enabled_for_new_repositories: true,
+      secret_scanning_push_protection_enabled_for_new_repositories: true
+    })
+    const repoData = generateGithubRepoData({
+      org,
+      name: 'repo1',
+      secret_scanning_status: 'enabled',
+      secret_scanning_push_protection_status: 'enabled',
+      secret_scanning_non_provider_patterns_status: 'enabled'
+    })
+    await addGithubRepo(repoData)
+
+    // Add hypothetical existing alerts and tasks
+    await addAlert({ compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+    await addTask({ compliance_check_id: check.id, project_id: project.id, title: 'existing', description: 'existing', severity: 'critical' })
+
+    // Check that the database has the expected results
+    let results = await getAllResults()
+    expect(results.length).toBe(0)
+
+    let alerts = await getAllAlerts()
+    expect(alerts.length).toBe(1)
+    expect(alerts[0].compliance_check_id).toBe(check.id)
+    let tasks = await getAllTasks()
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].compliance_check_id).toBe(check.id)
+
+    // Run the check
+    await scanCommitsForSensitiveInfo(knex)
+    // Check that the database has the expected results
+    results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('passed')
+    alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+  })
+
+  it('Should add (alerts and tasks) and update results if some org-level check is disabled', async () => {
+    const org = await addGithubOrg({
+      login: sampleGithubOrg.login,
+      html_url: sampleGithubOrg.html_url,
+      project_id: project.id,
+      secret_scanning_enabled_for_new_repositories: false
+    })
+    const repoData = generateGithubRepoData({ org, name: 'repo1', secret_scanning_status: 'enabled' })
+    await addGithubRepo(repoData)
+    await addResult({
+      compliance_check_id: check.id,
+      project_id: project.id,
+      status: 'passed',
+      rationale: 'failed previously',
+      severity: 'critical'
+    })
+
+    // Check that the database has the expected results
+    let results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].compliance_check_id).toBe(check.id)
+
+    let alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    let tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+
+    // Run the check
+    await scanCommitsForSensitiveInfo(knex)
+    // Check that the database has the expected results
+    results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('failed')
+    expect(results[0].rationale).not.toBe('failed previously')
+
+    alerts = await getAllAlerts()
+    expect(alerts.length).toBe(1)
+    expect(alerts[0].compliance_check_id).toBe(check.id)
+    tasks = await getAllTasks()
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].compliance_check_id).toBe(check.id)
+  })
+
+  it('Should add (alerts and tasks) and update results if some repo-level check is not set', async () => {
+    const org = await addGithubOrg({
+      login: sampleGithubOrg.login,
+      html_url: sampleGithubOrg.html_url,
+      project_id: project.id,
+      secret_scanning_enabled_for_new_repositories: true,
+      secret_scanning_push_protection_enabled_for_new_repositories: true
+    })
+    const repoData = generateGithubRepoData({
+      org,
+      name: 'repo1',
+      secret_scanning_status: 'enabled',
+      secret_scanning_push_protection_status: undefined,
+      secret_scanning_non_provider_patterns_status: undefined
+    })
+    await addGithubRepo(repoData)
+    await addResult({
+      compliance_check_id: check.id,
+      project_id: project.id,
+      status: 'passed',
+      rationale: 'failed previously',
+      severity: 'critical'
+    })
+
+    // Check that the database has the expected results
+    let results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].compliance_check_id).toBe(check.id)
+
+    let alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    let tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+
+    // Run the check
+    await scanCommitsForSensitiveInfo(knex)
+    // Check that the database has the expected results
+    results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('failed')
+    expect(results[0].severity).toBe('critical')
+    expect(results[0].rationale).toContain('repositories do not have the secret scanning in commits capabilities enabled')
+
+    alerts = await getAllAlerts()
+    expect(alerts.length).toBe(1)
+    expect(alerts[0].compliance_check_id).toBe(check.id)
+    tasks = await getAllTasks()
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].compliance_check_id).toBe(check.id)
+  })
+
+  it('Should add (alerts and tasks) and update results with no repos', async () => {
+    // Prepare the Scenario
+    await addGithubOrg({ login: sampleGithubOrg.login, html_url: sampleGithubOrg.html_url, project_id: project.id, secret_scanning_enabled_for_new_repositories: false })
+
+    await addResult({ compliance_check_id: check.id, project_id: project.id, status: 'passed', rationale: 'failed previously', severity: 'critical' })
+    // Check that the database has the expected results
+    let results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].compliance_check_id).toBe(check.id)
+
+    let alerts = await getAllAlerts()
+    expect(alerts.length).toBe(0)
+    let tasks = await getAllTasks()
+    expect(tasks.length).toBe(0)
+
+    // Run the check
+    await scanCommitsForSensitiveInfo(knex)
+    // Check that the database has the expected results
+    results = await getAllResults()
+    expect(results.length).toBe(1)
+    expect(results[0].status).toBe('failed')
+    expect(results[0].rationale).not.toBe('failed previously')
+
+    alerts = await getAllAlerts()
+    expect(alerts.length).toBe(1)
+    expect(alerts[0].compliance_check_id).toBe(check.id)
+    tasks = await getAllTasks()
+    expect(tasks.length).toBe(1)
+    expect(tasks[0].compliance_check_id).toBe(check.id)
+  })
+})

--- a/__tests__/checks/validators/scanCommitsForSensitiveInfo.test.js
+++ b/__tests__/checks/validators/scanCommitsForSensitiveInfo.test.js
@@ -1,0 +1,403 @@
+const { se } = require('date-fns/locale')
+const { scanCommitsForSensitiveInfo } = require('../../../src/checks/validators')
+
+describe('scanCommitsForSensitiveInfo', () => {
+  let projectsFixture, check, projects
+  beforeEach(() => {
+    projectsFixture = [
+      {
+        project_id: 1,
+        secret_scanning_enabled_for_new_repositories: true,
+        secret_scanning_push_protection_enabled_for_new_repositories: true,
+        github_organization_id: 1,
+        login: 'org1',
+        repositories: [
+          {
+            id: 1,
+            secret_scanning_status: 'enabled',
+            secret_scanning_push_protection_status: 'enabled',
+            secret_scanning_non_provider_patterns_status: 'enabled',
+            name: 'test',
+            full_name: 'org1/test'
+          },
+          {
+            id: 2,
+            secret_scanning_status: 'enabled',
+            secret_scanning_push_protection_status: 'enabled',
+            secret_scanning_non_provider_patterns_status: 'enabled',
+            name: 'discussions',
+            full_name: 'org1/discussions'
+          }
+        ]
+      }, {
+        project_id: 1,
+        secret_scanning_enabled_for_new_repositories: true,
+        secret_scanning_push_protection_enabled_for_new_repositories: true,
+        github_organization_id: 2,
+        login: 'org2',
+        repositories: [
+          {
+            id: 3,
+            secret_scanning_status: 'enabled',
+            secret_scanning_push_protection_status: 'enabled',
+            secret_scanning_non_provider_patterns_status: 'enabled',
+            name: '.github',
+            full_name: 'org2/.github'
+          }
+        ]
+      }, {
+        project_id: 2,
+        secret_scanning_enabled_for_new_repositories: true,
+        secret_scanning_push_protection_enabled_for_new_repositories: true,
+        github_organization_id: 3,
+        login: 'org3',
+        repositories: [
+          {
+            id: 4,
+            secret_scanning_status: 'enabled',
+            secret_scanning_push_protection_status: 'enabled',
+            secret_scanning_non_provider_patterns_status: 'enabled',
+            name: 'support',
+            full_name: 'org3/support'
+          }
+        ]
+      }]
+
+    check = {
+      id: 1,
+      default_priority_group: 'P2',
+      details_url: 'https://example.com'
+    }
+
+    projects = [
+      {
+        id: 1
+      },
+      {
+        id: 2
+      }
+    ]
+  })
+
+  it('Should generate a passed result if all organizations and repositories have secret scanning in commits full enabled', () => {
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'passed',
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled'
+        },
+        {
+          compliance_check_id: 1,
+          project_id: 2,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: []
+    })
+  })
+
+  it('should generate a failed result if some organizations do not have some secret scanning capabilities enabled, but existing repositories do have it enabled', () => {
+    projectsFixture[0].secret_scanning_enabled_for_new_repositories = false
+    // IMPORTANT: If one organization fails, the whole project fails no matter how other organizations are in the project
+    projectsFixture[1].secret_scanning_enabled_for_new_repositories = null
+    // data[1].secret_scanning_push_protection_enabled_for_new_repositories = false
+
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'The organization(s) org1 has not enabled all secret scanning in commits capabilities by default. All repositories have all the secret scanning in commits capabilities enabled',
+          description: 'Check the details on https://example.com'
+        }
+      ],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'failed',
+          rationale: 'The organization(s) org1 has not enabled all secret scanning in commits capabilities by default. All repositories have all the secret scanning in commits capabilities enabled'
+
+        },
+        {
+          project_id: 2,
+          compliance_check_id: 1,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'Enable secret scanning in commits for the organization(s) org1',
+          description: 'Check the details on https://example.com'
+        }
+      ]
+    })
+  })
+
+  it('should generate a failed result if some organizations and repositories do not have secret scanning enabled for new repositories', () => {
+    projectsFixture[0].secret_scanning_enabled_for_new_repositories = false
+    projectsFixture[0].repositories[0].secret_scanning_status = 'disabled'
+    projectsFixture[1].secret_scanning_enabled_for_new_repositories = false
+    projectsFixture[1].repositories[0].secret_scanning_status = 'disabled'
+
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'The organization(s) org1, org2 has not enabled all secret scanning in commits capabilities by default. 2 (66.7%) repositories do not have the secret scanning in commits capabilities enabled',
+          description: 'Check the details on https://example.com'
+        }
+      ],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'failed',
+          rationale: 'The organization(s) org1, org2 has not enabled all secret scanning in commits capabilities by default. 2 (66.7%) repositories do not have the secret scanning in commits capabilities enabled'
+        },
+        {
+          compliance_check_id: 1,
+          project_id: 2,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'Enable secret scanning in commits for the organization(s) org1, org2 and 2 (66.7%) repositories',
+          description: 'Check the details on https://example.com'
+        }
+      ]
+    })
+  })
+
+  it('should generate a failed result if some and repositories do not have secret scanning enabled in commits', () => {
+    projectsFixture[1].repositories[0].secret_scanning_non_provider_patterns_status = 'disabled'
+
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'The organization(s) has all secret scanning commits capabilities for repositories enabled. 1 (33.3%) repositories do not have the secret scanning in commits capabilities enabled',
+          description: 'Check the details on https://example.com'
+        }
+      ],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'failed',
+          rationale: 'The organization(s) has all secret scanning commits capabilities for repositories enabled. 1 (33.3%) repositories do not have the secret scanning in commits capabilities enabled'
+        },
+        {
+          compliance_check_id: 1,
+          project_id: 2,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          title: 'Enable secret scanning in commits for 1 (33.3%) repositories (org2/.github) in GitHub',
+          description: 'Check the details on https://example.com'
+        }
+      ]
+    })
+  })
+
+  it('should generate an unknown result if some organizations have unknown secret enabled, but existing repositories do have it enabled', () => {
+    projectsFixture[0].secret_scanning_enabled_for_new_repositories = null
+
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'unknown',
+          rationale: 'It was not possible to confirm if the following organization(s) has enabled all secret scanning in commits capabilities: org1'
+        },
+        {
+          compliance_check_id: 1,
+          project_id: 2,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: []
+    })
+  })
+
+  it('should generate an unknown result if all organizations have secret enabled, but some repositories have unknown secret enabled', () => {
+    projectsFixture[0].repositories[0].secret_scanning_push_protection_status = null
+
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'unknown',
+          rationale: 'It was not possible to confirm if some repositories have not enabled secret scanning in commits capabilities'
+        },
+        {
+          compliance_check_id: 1,
+          project_id: 2,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: []
+    })
+  })
+
+  it('should generate an unknown result if a mixture some organizations and some repositories have unknown secret enabled', () => {
+    projectsFixture[0].repositories[0].secret_scanning_push_protection_status = null
+    projectsFixture[0].secret_scanning_enabled_for_new_repositories = null
+
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'unknown',
+          rationale: 'It was not possible to confirm if some organizations and repositories have secret scanning in commits enabled'
+        },
+        {
+          compliance_check_id: 1,
+          project_id: 2,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: []
+    })
+  })
+
+  it('should generate an failed result if some organizations have unknown secret scanning and some repositories don\'t have secret enabled', () => {
+    projectsFixture[0].secret_scanning_enabled_for_new_repositories = null
+    projectsFixture[0].repositories[0].secret_scanning_push_protection_status = 'disabled'
+
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [
+        {
+          compliance_check_id: 1,
+          description: 'Check the details on https://example.com',
+          project_id: 1,
+          severity: 'critical',
+          title: 'It was not possible to confirm if the following organization(s) has enabled all secret scanning in commits capabilities: org1. 1 (33.3%) repositories do not have the secret scanning in commits capabilities enabled'
+        }
+      ],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'failed',
+          rationale: 'It was not possible to confirm if the following organization(s) has enabled all secret scanning in commits capabilities: org1. 1 (33.3%) repositories do not have the secret scanning in commits capabilities enabled'
+        },
+        {
+          project_id: 2,
+          compliance_check_id: 1,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: [
+        {
+          compliance_check_id: 1,
+          description: 'Check the details on https://example.com',
+          project_id: 1,
+          severity: 'critical',
+          title: 'Enable secret scanning in commits for 1 (33.3%) repositories (org1/test) in GitHub'
+        }
+      ]
+    })
+  })
+
+  it('should generate an failed result if some organizations don\'t have secret scanning and some repositories have unknown secret enabled', () => {
+    projectsFixture[0].secret_scanning_push_protection_enabled_for_new_repositories = false
+    projectsFixture[1].repositories[0].secret_scanning_non_provider_patterns_status = null
+
+    const analysis = scanCommitsForSensitiveInfo({ data: projectsFixture, check, projects })
+    expect(analysis).toEqual({
+      alerts: [
+        {
+          compliance_check_id: 1,
+          description: 'Check the details on https://example.com',
+          project_id: 1,
+          severity: 'critical',
+          title: 'The organization(s) org1 has not enabled all secret scanning in commits capabilities by default. It was not possible to confirm if some repositories have not enabled secret scanning in commits capabilities'
+        }
+      ],
+      results: [
+        {
+          project_id: 1,
+          compliance_check_id: 1,
+          severity: 'critical',
+          status: 'failed',
+          rationale: 'The organization(s) org1 has not enabled all secret scanning in commits capabilities by default. It was not possible to confirm if some repositories have not enabled secret scanning in commits capabilities'
+        },
+        {
+          compliance_check_id: 1,
+          project_id: 2,
+          rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled',
+          severity: 'critical',
+          status: 'passed'
+        }
+      ],
+      tasks: [
+        {
+          compliance_check_id: 1,
+          description: 'Check the details on https://example.com',
+          project_id: 1,
+          severity: 'critical',
+          title: 'Enable secret scanning in commits for the organization(s) org1'
+        }
+      ]
+    })
+  })
+})

--- a/__tests__/checks/validators/scanCommitsForSensitiveInfo.test.js
+++ b/__tests__/checks/validators/scanCommitsForSensitiveInfo.test.js
@@ -1,4 +1,3 @@
-const { se } = require('date-fns/locale')
 const { scanCommitsForSensitiveInfo } = require('../../../src/checks/validators')
 
 describe('scanCommitsForSensitiveInfo', () => {

--- a/src/checks/complianceChecks/scanCommitsForSensitiveInfo.js
+++ b/src/checks/complianceChecks/scanCommitsForSensitiveInfo.js
@@ -1,0 +1,32 @@
+const validators = require('../validators')
+const { initializeStore } = require('../../store')
+const debug = require('debug')('checks:noSensitiveInfoInRepositories')
+
+module.exports = async (knex, { projects } = {}) => {
+  const {
+    getAllGithubRepositoriesAndOrganizationByProjectId, getCheckByCodeName,
+    getAllProjects, addAlert, addTask, upsertComplianceCheckResult,
+    deleteAlertsByComplianceCheckId, deleteTasksByComplianceCheckId
+  } = initializeStore(knex)
+  debug('Collecting relevant data...')
+
+  const check = await getCheckByCodeName('noSensitiveInfoInRepositories')
+  if (!projects || (Array.isArray(projects) && projects.length === 0)) {
+    projects = await getAllProjects()
+  }
+
+  const data = await getAllGithubRepositoriesAndOrganizationByProjectId(projects.map(p => p.id))
+  debug('Extracting the validation results...')
+  const analysis = validators.noSensitiveInfoInRepositories({ data, check, projects })
+
+  debug('Deleting previous alerts and tasks to avoid orphaned records...')
+  await deleteAlertsByComplianceCheckId(check.id)
+  await deleteTasksByComplianceCheckId(check.id)
+
+  debug('Upserting the new results...')
+  await Promise.all(analysis.results.map(result => upsertComplianceCheckResult(result)))
+
+  debug('Inserting the new Alerts and Tasks...')
+  await Promise.all(analysis.alerts.map(alert => addAlert(alert)))
+  await Promise.all(analysis.tasks.map(task => addTask(task)))
+}

--- a/src/checks/complianceChecks/scanCommitsForSensitiveInfo.js
+++ b/src/checks/complianceChecks/scanCommitsForSensitiveInfo.js
@@ -1,6 +1,6 @@
 const validators = require('../validators')
 const { initializeStore } = require('../../store')
-const debug = require('debug')('checks:noSensitiveInfoInRepositories')
+const debug = require('debug')('checks:scanCommitsForSensitiveInfo')
 
 module.exports = async (knex, { projects } = {}) => {
   const {
@@ -10,14 +10,14 @@ module.exports = async (knex, { projects } = {}) => {
   } = initializeStore(knex)
   debug('Collecting relevant data...')
 
-  const check = await getCheckByCodeName('noSensitiveInfoInRepositories')
+  const check = await getCheckByCodeName('scanCommitsForSensitiveInfo')
   if (!projects || (Array.isArray(projects) && projects.length === 0)) {
     projects = await getAllProjects()
   }
 
   const data = await getAllGithubRepositoriesAndOrganizationByProjectId(projects.map(p => p.id))
   debug('Extracting the validation results...')
-  const analysis = validators.noSensitiveInfoInRepositories({ data, check, projects })
+  const analysis = validators.scanCommitsForSensitiveInfo({ data, check, projects })
 
   debug('Deleting previous alerts and tasks to avoid orphaned records...')
   await deleteAlertsByComplianceCheckId(check.id)

--- a/src/checks/validators/index.js
+++ b/src/checks/validators/index.js
@@ -4,6 +4,7 @@ const owaspTop10Training = require('./owaspTop10Training')
 const adminRepoCreationOnly = require('./adminRepoCreationOnly')
 const noSensitiveInfoInRepositories = require('./noSensitiveInfoInRepositories')
 const genericProjectPolicyValidator = require('./genericProjectPolicyValidator')
+const scanCommitsForSensitiveInfo = require('./scanCommitsForSensitiveInfo')
 
 const validators = {
   githubOrgMFA,
@@ -11,6 +12,7 @@ const validators = {
   owaspTop10Training,
   adminRepoCreationOnly,
   noSensitiveInfoInRepositories,
+  scanCommitsForSensitiveInfo,
   // Generic Policies
   defineFunctionalRoles: genericProjectPolicyValidator('defineFunctionalRoles'),
   orgToolingMFA: genericProjectPolicyValidator('orgToolingMFA'),

--- a/src/checks/validators/scanCommitsForSensitiveInfo.js
+++ b/src/checks/validators/scanCommitsForSensitiveInfo.js
@@ -1,0 +1,210 @@
+const debug = require('debug')('checks:validator:scanCommitsForSensitiveInfo')
+const {
+  getSeverityFromPriorityGroup,
+  groupArrayItemsByCriteria,
+  generatePercentage
+} = require('../../utils')
+
+const groupByProject = groupArrayItemsByCriteria('project_id')
+
+function getOrgFailures (projectOrgs) {
+  const failedOrgs = projectOrgs
+    .filter(
+      (org) => (
+        org.secret_scanning_enabled_for_new_repositories === false ||
+        org.secret_scanning_push_protection_enabled_for_new_repositories === false)
+    )
+    .map((org) => org.login)
+
+  const unknownOrgs = projectOrgs
+    .filter(
+      (org) => (
+        org.secret_scanning_enabled_for_new_repositories === null ||
+        org.secret_scanning_push_protection_enabled_for_new_repositories === null)
+    )
+    .map((org) => org.login)
+
+  return { failedOrgs, unknownOrgs }
+}
+
+function getRepoFailures (repositories) {
+  const failedRepos = repositories
+    .filter(repo => repo.secret_scanning_status === 'disabled' ||
+      repo.secret_scanning_push_protection_status === 'disabled' ||
+      repo.secret_scanning_non_provider_patterns_status === 'disabled')
+    .map(repo => repo.full_name)
+
+  const unknownRepos = repositories
+    .filter(
+      (repo) =>
+        repo.secret_scanning_status === null ||
+        repo.secret_scanning_push_protection_status === null ||
+        repo.secret_scanning_non_provider_patterns_status === null
+    )
+    .map((repo) => repo.full_name)
+
+  return { failedRepos, unknownRepos }
+}
+
+function buildOrgMessage (failedOrgs, unknownOrgs) {
+  if (failedOrgs.length) {
+    return `The organization(s) ${failedOrgs.join(', ')} has not enabled all secret scanning in commits capabilities by default`
+  }
+  if (unknownOrgs.length) {
+    return `It was not possible to confirm if the following organization(s) has enabled all secret scanning in commits capabilities: ${unknownOrgs.join(', ')}`
+  }
+  return 'The organization(s) has all secret scanning commits capabilities for repositories enabled'
+}
+
+function buildRepoMessage (failedRepos, unknownRepos, totalRepos) {
+  const percentage = generatePercentage(totalRepos, failedRepos.length)
+
+  if (failedRepos.length) {
+    return `${failedRepos.length} (${percentage}) repositories do not have the secret scanning in commits capabilities enabled`
+  }
+  if (unknownRepos.length) {
+    return 'It was not possible to confirm if some repositories have not enabled secret scanning in commits capabilities'
+  }
+  return 'All repositories have all the secret scanning in commits capabilities enabled'
+}
+
+// @see: https://github.com/OpenPathfinder/visionBoard/issues/67
+module.exports = ({ data: ghOrgs, check, projects }) => {
+  debug('Validating that secret scanning in commits is enabled...')
+  debug('Grouping repositories by project...')
+  const ghOrgsGroupedByProject = groupByProject(ghOrgs)
+
+  const alerts = []
+  const results = []
+  const tasks = []
+
+  debug('Processing repositories...')
+  ghOrgsGroupedByProject.forEach((projectOrgs) => {
+    debug(`Processing Project (${projectOrgs[0].github_organization_id})`)
+
+    const project = projects.find(p => p.id === projectOrgs[0].project_id)
+    const projectRepositories = projectOrgs.map(org => org.repositories).flat()
+
+    const baseData = {
+      project_id: project.id,
+      compliance_check_id: check.id,
+      severity: getSeverityFromPriorityGroup(check.default_priority_group)
+    }
+
+    // Early check: if absolutely everything is enabled, we pass and move on
+    const allReposEnabled = projectRepositories.every(
+      repo => repo.secret_scanning_status === 'enabled' &&
+        repo.secret_scanning_non_provider_patterns_status === 'enabled' &&
+        repo.secret_scanning_push_protection_status === 'enabled'
+    )
+    const allOrgDefaultsEnabled = projectOrgs.every(
+      org => org.secret_scanning_enabled_for_new_repositories === true &&
+        org.secret_scanning_push_protection_enabled_for_new_repositories === true
+    )
+
+    if (allReposEnabled && allOrgDefaultsEnabled) {
+      results.push({
+        ...baseData,
+        status: 'passed',
+        rationale: 'The organizations(s) and repositories have secret scanning in commits full enabled'
+      })
+      debug(`Processed project (${project.id}) - All passed`)
+      return
+    }
+
+    // Otherwise, gather failures/unknowns
+    const { failedOrgs, unknownOrgs } = getOrgFailures(projectOrgs)
+    const { failedRepos, unknownRepos } = getRepoFailures(projectRepositories)
+
+    // Build rationale pieces
+    const rationaleOrg = buildOrgMessage(failedOrgs, unknownOrgs)
+    const rationaleRepo = buildRepoMessage(
+      failedRepos,
+      unknownRepos,
+      projectRepositories.length
+    )
+
+    // Determine the overall status
+    const hasFailures = failedOrgs.length > 0 || failedRepos.length > 0
+    const hasUnknowns = unknownOrgs.length > 0 || unknownRepos.length > 0
+
+    let status = 'passed'
+    if (hasFailures) {
+      status = 'failed'
+    } else if (hasUnknowns) {
+      status = 'unknown'
+    }
+
+    // Determine the combined rationale
+    let rationale
+    if (hasFailures) {
+      rationale = `${rationaleOrg}. ${rationaleRepo}`
+    } else if (hasUnknowns) {
+      // We have no failures, but some unknowns
+      // A bit more specific: if we only have unknown orgs or unknown repos
+      rationale = unknownOrgs.length && unknownRepos.length
+        ? 'It was not possible to confirm if some organizations and repositories have secret scanning in commits enabled'
+        : unknownOrgs.length
+          ? rationaleOrg
+          : rationaleRepo
+    }
+
+    const result = {
+      ...baseData,
+      status,
+      rationale
+    }
+
+    // Build alert and task **only** if we have failures
+    if (hasFailures) {
+      const alert = {
+        ...baseData,
+        title: `${rationaleOrg}. ${rationaleRepo}`,
+        description: `Check the details on ${check.details_url}`
+      }
+
+      // We unify the logic for the task title:
+      let taskTitle = ''
+
+      if (failedOrgs.length && failedRepos.length) {
+        const percentageOfFailedRepos = generatePercentage(
+          projectRepositories.length,
+          failedRepos.length
+        )
+        taskTitle = `Enable secret scanning in commits for the organization(s) ${failedOrgs.join(', ')} and ${failedRepos.length} (${percentageOfFailedRepos}) repositories`
+      } else if (failedOrgs.length) {
+        taskTitle = `Enable secret scanning in commits for the organization(s) ${failedOrgs.join(', ')}`
+      } else if (failedRepos.length) {
+        const percentageOfFailedRepos = generatePercentage(
+          projectRepositories.length,
+          failedRepos.length
+        )
+        // @TODO: The list of failed repos can be very big, so we might need to truncate it or remove it in future releases based on community feedback.
+        taskTitle = `Enable secret scanning in commits for ${failedRepos.length} (${percentageOfFailedRepos}) repositories (${failedRepos.join(', ')}) in GitHub`
+      }
+
+      // Only push if we really have something to do
+      if (taskTitle) {
+        const task = {
+          ...baseData,
+          title: taskTitle,
+          description: `Check the details on ${check.details_url}`
+        }
+        debug(`Adding task for project (${project.id})`)
+        tasks.push(task)
+
+        debug(`Adding alert for project (${project.id})`)
+        alerts.push(alert)
+      }
+    }
+
+    results.push(result)
+    debug(`Processed project (${project.id})`)
+  })
+
+  return {
+    alerts,
+    results,
+    tasks
+  }
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -6,7 +6,8 @@ const dbSettings = {
     host: process.env.DB_HOST || '0.0.0.0',
     user: process.env.DB_USER || 'visionBoard',
     password: process.env.DB_PASSWORD || 'password',
-    database: process.env.DB_NAME || 'dashboard'
+    database: process.env.DB_NAME || 'dashboard',
+    port: process.env.DB_PORT || 5432
   },
   ssl: normalizeBoolean(process.env.DB_SSL),
   pool: {

--- a/src/database/migrations/1742403845916_update_check_scanCommitsForSensitiveInfo.js.js
+++ b/src/database/migrations/1742403845916_update_check_scanCommitsForSensitiveInfo.js.js
@@ -1,0 +1,19 @@
+exports.up = async (knex) => {
+  await knex('compliance_checks')
+    .where({ code_name: 'scanCommitsForSensitiveInfo' })
+    .update({
+      implementation_status: 'completed',
+      implementation_type: 'computed',
+      implementation_details_reference: 'https://github.com/OpenPathfinder/visionBoard/issues/69'
+    })
+}
+
+exports.down = async (knex) => {
+  await knex('compliance_checks')
+    .where({ code_name: 'scanCommitsForSensitiveInfo' })
+    .update({
+      implementation_status: 'pending',
+      implementation_type: null,
+      implementation_details_reference: null
+    })
+}

--- a/src/database/schema/schema.sql
+++ b/src/database/schema/schema.sql
@@ -1302,7 +1302,7 @@ ALTER TABLE ONLY public.owasp_top10_training
 --
 
 ALTER TABLE ONLY public.resources_for_compliance_checks
-    ADD CONSTRAINT resources_for_compliance_checks_compliance_check_id_foreign FOREIGN KEY (compliance_check_id) REFERENCES public.compliance_checks(id);
+    ADD CONSTRAINT resources_for_compliance_checks_compliance_check_id_foreign FOREIGN KEY (compliance_check_id) REFERENCES public.compliance_checks(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -1310,7 +1310,7 @@ ALTER TABLE ONLY public.resources_for_compliance_checks
 --
 
 ALTER TABLE ONLY public.resources_for_compliance_checks
-    ADD CONSTRAINT resources_for_compliance_checks_compliance_check_resource_id_fo FOREIGN KEY (compliance_check_resource_id) REFERENCES public.compliance_checks_resources(id);
+    ADD CONSTRAINT resources_for_compliance_checks_compliance_check_resource_id_fo FOREIGN KEY (compliance_check_resource_id) REFERENCES public.compliance_checks_resources(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --


### PR DESCRIPTION
Addresses #69 .

As commented there, overlaps `noSensitiveInfoInRepositories` but expands to do checks in commits as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a compliance check for scanning commits for sensitive information, evaluating secret scanning settings at both organization and repository levels.
  * Added alerts and remediation tasks for projects that do not meet secret scanning requirements.

* **Bug Fixes**
  * Improved database schema to ensure related records are automatically updated or deleted when compliance checks or resources are changed.

* **Tests**
  * Added comprehensive integration and validation tests covering multiple scenarios for secret scanning compliance.

* **Chores**
  * Updated database configuration to support specifying a custom port.
  * Enhanced compliance check metadata and documentation references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->