### PR TITLE
feat: remove `show-reports` workflow

### DIFF
--- a/__tests__/cli/__snapshots__/workflows.test.js.snap
+++ b/__tests__/cli/__snapshots__/workflows.test.js.snap
@@ -23,11 +23,6 @@ exports[`list - Non-Interactive Mode Should provide a list of available workflow
     "workflow": [Function],
   },
   {
-    "description": "Starts a http server that shows all the files and folders in the output directory.",
-    "name": "show-reports",
-    "workflow": [Function],
-  },
-  {
     "description": "Generate the reports for the stored data.",
     "name": "generate-reports",
     "workflow": [Function],

--- a/__tests__/cli/workflows.test.js
+++ b/__tests__/cli/workflows.test.js
@@ -165,10 +165,6 @@ describe('run bulk-import', () => {
   test.todo('Should throw an error when the JSON file is not valid due schema validation')
 })
 
-describe('run show-reports', () => {
-  test.todo('Should start a http server that shows all the files and folders in the output directory')
-})
-
 describe('run generate-reports', () => {
   test.todo('Should generate the reports for the stored data')
 })

--- a/src/cli/workflows.js
+++ b/src/cli/workflows.js
@@ -22,10 +22,6 @@ const commandList = [{
   description: 'Upsert the OSSF Scorecard scoring by running and checking every repository in the database.',
   workflow: upsertOSSFScorecardAnalysis
 }, {
-  name: 'show-reports',
-  description: 'Starts a http server that shows all the files and folders in the output directory.',
-  workflow: require('../httpServer')
-}, {
   name: 'generate-reports',
   description: 'Generate the reports for the stored data.',
   workflow: generateStaticReports


### PR DESCRIPTION
Related #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the "show-reports" command from the CLI, eliminating its related functionality and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->