### PR TITLE
deps: bump postgres from 17.2 to 17.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17.2
+        image: postgres:17.4
         env:
           POSTGRES_DB: dashboard
           POSTGRES_USER: visionBoard

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17.2
+        image: postgres:17.4
         env:
           POSTGRES_DB: dashboard
           POSTGRES_USER: visionBoard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:17.2
+    image: postgres:17.4
     restart: always
     environment:
       POSTGRES_DB: dashboard
@@ -33,7 +33,7 @@ services:
       start_period: 5s
 
   schema-dump:
-    image: postgres:17.2
+    image: postgres:17.4
     depends_on:
       - db
     environment:

--- a/src/database/schema/schema.sql
+++ b/src/database/schema/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 17.2 (Debian 17.2-1.pgdg120+1)
--- Dumped by pg_dump version 17.2 (Debian 17.2-1.pgdg120+1)
+-- Dumped from database version 17.4 (Debian 17.4-1.pgdg120+2)
+-- Dumped by pg_dump version 17.4 (Debian 17.4-1.pgdg120+2)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1302,7 +1302,7 @@ ALTER TABLE ONLY public.owasp_top10_training
 --
 
 ALTER TABLE ONLY public.resources_for_compliance_checks
-    ADD CONSTRAINT resources_for_compliance_checks_compliance_check_id_foreign FOREIGN KEY (compliance_check_id) REFERENCES public.compliance_checks(id);
+    ADD CONSTRAINT resources_for_compliance_checks_compliance_check_id_foreign FOREIGN KEY (compliance_check_id) REFERENCES public.compliance_checks(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -1310,7 +1310,7 @@ ALTER TABLE ONLY public.resources_for_compliance_checks
 --
 
 ALTER TABLE ONLY public.resources_for_compliance_checks
-    ADD CONSTRAINT resources_for_compliance_checks_compliance_check_resource_id_fo FOREIGN KEY (compliance_check_resource_id) REFERENCES public.compliance_checks_resources(id);
+    ADD CONSTRAINT resources_for_compliance_checks_compliance_check_resource_id_fo FOREIGN KEY (compliance_check_resource_id) REFERENCES public.compliance_checks_resources(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --


### PR DESCRIPTION
Postgres is being updated to the latest version. I believe this isn't in production yet, so there's nothing to do for now, besides that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated PostgreSQL image version to 17.4 in Docker Compose and CI workflows for improved stability and security.
  - Enhanced database integrity by adding cascading updates and deletes to key foreign key constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->