### PR TITLE
feat: add `name` and `version` to `GET /__health endpoint`

### DIFF
--- a/__tests__/httpServer/apiV1.test.js
+++ b/__tests__/httpServer/apiV1.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest')
 const { generateStaticReports } = require('../../src/reports')
+const pkg = require('../../package.json')
 const serverModule = require('../../src/httpServer')
 let server
 let serverStop
@@ -35,6 +36,8 @@ describe('HTTP Server API V1', () => {
       expect(response.status).toBe(200)
       expect(response.body).toHaveProperty('status', 'ok')
       expect(response.body).toHaveProperty('timestamp')
+      expect(response.body).toHaveProperty('version', pkg.version)
+      expect(response.body).toHaveProperty('name', pkg.name)
 
       const timestamp = new Date(response.body.timestamp)
       expect(timestamp.toISOString()).toBe(response.body.timestamp)

--- a/src/httpServer/routers/apiV1.js
+++ b/src/httpServer/routers/apiV1.js
@@ -1,11 +1,12 @@
 const { generateStaticReports } = require('../../reports')
+const pkg = require('../../../package.json')
 const { logger } = require('../../utils')
 
 function createApiRouter (knex, express) {
   const router = express.Router()
 
   router.get('/__health', (req, res) => {
-    res.json({ status: 'ok', timestamp: new Date().toISOString() })
+    res.json({ status: 'ok', timestamp: new Date().toISOString(), version: pkg.version, name: pkg.name })
   })
 
   router.post('/generate-reports', async (req, res) => {

--- a/src/httpServer/swagger/api-v1.yml
+++ b/src/httpServer/swagger/api-v1.yml
@@ -28,9 +28,17 @@ paths:
                     type: string
                     format: date-time
                     example: '2025-05-03T07:20:16.000Z'
+                  name:
+                    type: string
+                    example: visionboard
+                  version:
+                    type: string
+                    example: 1.0.0
                 required:
                   - status
                   - timestamp
+                  - name
+                  - version
   
   /api/v1/generate-reports:
     post:


### PR DESCRIPTION
Related #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The health check endpoint now includes the application's name and version in its response.
- **Documentation**
  - Updated the API documentation to reflect the new response fields for the health check endpoint.
- **Tests**
  - Enhanced tests to verify that the health check endpoint returns the correct name and version values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->