### PR TITLE
feat: remove `POST /api/v1/generate-reports` endpoint

### DIFF
--- a/__tests__/httpServer/apiV1.test.js
+++ b/__tests__/httpServer/apiV1.test.js
@@ -20,7 +20,6 @@ jest.mock('../../src/cli/workflows', () => ({
 }))
 
 const request = require('supertest')
-const { generateStaticReports } = require('../../src/reports')
 const knexInit = require('knex')
 const { getConfig } = require('../../src/config')
 const { resetDatabase, initializeStore } = require('../../__utils__')
@@ -222,43 +221,5 @@ describe('HTTP Server API V1', () => {
     })
 
     test.todo('should return 500 when workflow execution times out')
-  })
-
-  describe('POST /api/v1/generate-reports', () => {
-    test('should return status completed when report generation succeeds', async () => {
-      generateStaticReports.mockResolvedValueOnce()
-
-      const response = await app.post('/api/v1/generate-reports')
-
-      expect(generateStaticReports).toHaveBeenCalledWith(expect.anything(), { clearPreviousReports: true })
-      expect(response.status).toBe(202)
-      expect(response.body).toHaveProperty('status', 'completed')
-      expect(response.body).toHaveProperty('startedAt')
-      expect(response.body).toHaveProperty('finishedAt')
-
-      const startedAt = new Date(response.body.startedAt)
-      const finishedAt = new Date(response.body.finishedAt)
-      expect(startedAt.toISOString()).toBe(response.body.startedAt)
-      expect(finishedAt.toISOString()).toBe(response.body.finishedAt)
-      expect(finishedAt.getTime()).toBeGreaterThanOrEqual(startedAt.getTime())
-    })
-
-    test('should return status failed when report generation fails', async () => {
-      generateStaticReports.mockRejectedValueOnce(new Error('Report generation failed'))
-
-      const response = await app.post('/api/v1/generate-reports')
-
-      expect(generateStaticReports).toHaveBeenCalledWith(expect.anything(), { clearPreviousReports: true })
-      expect(response.status).toBe(500)
-      expect(response.body).toHaveProperty('status', 'failed')
-      expect(response.body).toHaveProperty('startedAt')
-      expect(response.body).toHaveProperty('finishedAt')
-
-      const startedAt = new Date(response.body.startedAt)
-      const finishedAt = new Date(response.body.finishedAt)
-      expect(startedAt.toISOString()).toBe(response.body.startedAt)
-      expect(finishedAt.toISOString()).toBe(response.body.finishedAt)
-      expect(finishedAt.getTime()).toBeGreaterThanOrEqual(startedAt.getTime())
-    })
   })
 })

--- a/src/httpServer/routers/apiV1.js
+++ b/src/httpServer/routers/apiV1.js
@@ -1,4 +1,3 @@
-const { generateStaticReports } = require('../../reports')
 const pkg = require('../../../package.json')
 const { logger } = require('../../utils')
 const { initializeStore } = require('../../store')
@@ -105,24 +104,6 @@ function createApiRouter (knex, express) {
     }
   })
 
-  router.post('/generate-reports', async (req, res) => {
-    const startTs = new Date().toISOString()
-    try {
-      await generateStaticReports(knex, { clearPreviousReports: true })
-      res.status(202).json({
-        status: 'completed',
-        startedAt: startTs,
-        finishedAt: new Date().toISOString()
-      })
-    } catch (error) {
-      logger.error(error)
-      res.status(500).json({
-        status: 'failed',
-        startedAt: startTs,
-        finishedAt: new Date().toISOString()
-      })
-    }
-  })
   return router
 }
 

--- a/src/httpServer/swagger/api-v1.yml
+++ b/src/httpServer/swagger/api-v1.yml
@@ -197,62 +197,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /api/v1/generate-reports:
-    post:
-      summary: Generate static reports
-      description: Triggers the generation of static reports
-      operationId: generateReports
-      tags:
-        - Reports
-      responses:
-        '202':
-          description: Report generation accepted
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: false
-                properties:
-                  status:
-                    type: string
-                    enum: [completed, failed]
-                    example: completed
-                  startedAt:
-                    type: string
-                    format: date-time
-                    example: '2025-05-03T07:20:16.000Z'
-                  finishedAt:
-                    type: string
-                    format: date-time
-                    example: '2025-05-03T07:20:20.000Z'
-                required:
-                  - status
-                  - startedAt
-                  - finishedAt
-        '500':
-          description: Report generation failed
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: false
-                properties:
-                  status:
-                    type: string
-                    enum: [failed]
-                    example: failed
-                  startedAt:
-                    type: string
-                    format: date-time
-                    example: '2025-05-03T07:20:16.000Z'
-                  finishedAt:
-                    type: string
-                    format: date-time
-                    example: '2025-05-03T07:20:20.000Z'
-                required:
-                  - status
-                  - startedAt
-                  - finishedAt
 
 components:
   schemas:


### PR DESCRIPTION
Related #216

This now can be achieved by running `curl -X POST http://localhost:3000/api/v1/workflow/generate-reports/run   -H "Content-Type: application/json"`. Implemented in #241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- No new features were added in this release.

- **Bug Fixes**
	- No bug fixes are included in this release.

- **Documentation**
	- Removed documentation for the `/api/v1/generate-reports` endpoint from the API specification.

- **Refactor**
	- Updated workflow execution handling for improved consistency.

- **Chores**
	- Removed the `/api/v1/generate-reports` endpoint and its related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->