### PR TITLE
feat: add `GET /api/v1/check` endpoint

### DIFF
--- a/__tests__/httpServer/apiV1.test.js
+++ b/__tests__/httpServer/apiV1.test.js
@@ -36,6 +36,7 @@ let knex
 let getAllProjects
 let addProject
 let getAllGithubOrganizationsByProjectsId
+let getAllChecks
 
 beforeAll(async () => {
   // Initialize server asynchronously
@@ -47,7 +48,8 @@ beforeAll(async () => {
   ({
     getAllProjects,
     addProject,
-    getAllGithubOrganizationsByProjectsId
+    getAllGithubOrganizationsByProjectsId,
+    getAllChecks
   } = initializeStore(knex))
 })
 
@@ -383,6 +385,19 @@ describe('HTTP Server API V1', () => {
       expect(response.status).toBe(409)
       expect(response.body).toHaveProperty('errors')
       expect(response.body.errors[0]).toHaveProperty('message', 'GitHub organization already exists for this project')
+    })
+
+    test.todo('should return 500 for internal server error')
+  })
+
+  describe('GET /api/v1/check', () => {
+    test('should return 200 and a list of checks', async () => {
+      const response = await app.get('/api/v1/check')
+      const storedChecks = await getAllChecks()
+
+      expect(response.status).toBe(200)
+      // @TODO: find a more elegant way to solve the issue with the date format
+      expect(response.body).toStrictEqual(JSON.parse(JSON.stringify(storedChecks)))
     })
 
     test.todo('should return 500 for internal server error')

--- a/src/httpServer/routers/apiV1.js
+++ b/src/httpServer/routers/apiV1.js
@@ -27,7 +27,7 @@ const runWorkflow = ({ workflowName, knex, data } = {}) => new Promise((resolve,
 })
 
 function createApiRouter (knex, express) {
-  const { addProject, getProjectByName, addGithubOrganization, getProjectById, getAllGithubOrganizationsByProjectsId } = initializeStore(knex)
+  const { addProject, getProjectByName, addGithubOrganization, getProjectById, getAllGithubOrganizationsByProjectsId, getAllChecks } = initializeStore(knex)
 
   const router = express.Router()
 
@@ -118,6 +118,16 @@ function createApiRouter (knex, express) {
     } catch (err) {
       logger.error(err)
       return res.status(500).json({ errors: [{ message: 'Internal server error' }] })
+    }
+  })
+
+  router.get('/check', async (req, res) => {
+    try {
+      const checks = await getAllChecks()
+      res.json(checks)
+    } catch (error) {
+      logger.error(error)
+      res.status(500).json({ errors: [{ message: 'Failed to retrieve checks' }] })
     }
   })
 

--- a/src/httpServer/swagger/api-v1.yml
+++ b/src/httpServer/swagger/api-v1.yml
@@ -211,7 +211,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-
+  /api/v1/check:
+    get:
+      summary: List all checks
+      description: Returns a list of all checks
+      operationId: listChecks
+      tags:
+        - Checks
+      responses:
+        '200':
+          description: A list of checks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Check'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/project:
     post:
       summary: Create a new project
@@ -266,6 +287,79 @@ paths:
 
 components:
   schemas:
+    Check:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: integer
+          example: 53
+        title:
+          type: string
+          maxLength: 255
+          example: "Refresh dependencies with annual releases"
+        description:
+          type: string
+          example: "Ensure dependencies are refreshed through a new release at least once annually"
+        default_section_number:
+          type: string
+          maxLength: 255
+          example: "5"
+        default_section_name:
+          type: string
+          maxLength: 255
+          example: "vulnerability management"
+        code_name:
+          type: string
+          maxLength: 255
+          example: "annualDependencyRefresh"
+        default_priority_group:
+          type: string
+          enum: ["P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9", "P10", "P11", "P12", "P13", "P14", "R0", "R1", "R2", "R3", "R4", "R5", "R6", "R7", "R8", "R9", "R10", "R11", "R12", "R13", "R14"]
+          example: "P14"
+        is_c_scrm:
+          type: boolean
+          default: false
+          example: true
+        implementation_status:
+          type: string
+          enum: ["pending", "completed"]
+          default: "pending"
+          example: "completed"
+        # @TODO: Convert to enum when nullable values are removed
+        implementation_type:
+          type: string
+          nullable: true
+          example: "manual"
+        implementation_details_reference:
+          type: string
+          nullable: true
+          example: "https://github.com/OpenPathfinder/visionBoard/issues/112"
+        details_url:
+          type: string
+          example: "https://openpathfinder.com/docs/checks/annualDependencyRefresh"
+        created_at:
+          type: string
+          format: date-time
+          example: "2025-02-21T18:53:00.485Z"
+        updated_at:
+          type: string
+          format: date-time
+          example: "2025-02-21T18:53:00.485Z"
+      required:
+        - id
+        - title
+        - description
+        - default_section_number
+        - default_section_name
+        - code_name
+        - default_priority_group
+        - is_c_scrm
+        - implementation_status
+        - details_url
+        - created_at
+        - updated_at
+      
     GithubOrganization:
       type: object
       additionalProperties: false

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -248,7 +248,8 @@ const initializeStore = (knex) => {
     upsertOwaspTop10Training: upsertOwaspTop10Training(knex),
     getAllOSSFResults: () => getAll('ossf_scorecard_results'),
     getProjectById: (id) => getOne('projects', id),
-    getProjectByName: getProjectByName(knex)
+    getProjectByName: getProjectByName(knex),
+    getAllChecks: () => getAll('compliance_checks')
   }
 }
 


### PR DESCRIPTION
Related #216

![image](https://github.com/user-attachments/assets/bfbce1cb-44e0-4423-bb69-8fa8bee3594f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint `/api/v1/check` to retrieve a list of all checks.
  - Added comprehensive API documentation for the new endpoint, including a detailed schema for returned check objects.

- **Tests**
  - Added tests to verify the new endpoint returns the correct data and handles server errors appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->